### PR TITLE
Bağımlılık yükseltme planı

### DIFF
--- a/config.js
+++ b/config.js
@@ -121,18 +121,21 @@ function applyPostgresResilience(sequelizeInstance) {
     return false;
   };
 
-  const isAntiDeleteQuery = (sql) => {
+  const isAntiDeleteDml = (sql) => {
     if (!sql || typeof sql !== "string") return false;
-    return sql.toLowerCase().includes("antideletecache");
+    const lower = sql.toLowerCase();
+    if (!lower.includes("antideletecache")) return false;
+    const trimmed = lower.trimStart();
+    return trimmed.startsWith("insert") || trimmed.startsWith("update") || trimmed.startsWith("delete");
   };
 
   sequelizeInstance.query = function serializedQuery(sql, ...rest) {
-    if (isAntiDeleteQuery(sql)) {
-      return Promise.resolve([[], 0]);
-    }
-
     if (!isWriteQuery(sql)) {
       return originalQuery(sql, ...rest);
+    }
+
+    if (isAntiDeleteDml(sql)) {
+      return Promise.resolve([[], 0]);
     }
 
     if (isHighVolumeQuery(sql)) {
@@ -164,12 +167,12 @@ function applyPostgresResilience(sequelizeInstance) {
   if (typeof sequelizeInstance.queryRaw === "function") {
     const originalQueryRaw = sequelizeInstance.queryRaw.bind(sequelizeInstance);
     sequelizeInstance.queryRaw = function serializedQueryRaw(sql, ...rest) {
-      if (isAntiDeleteQuery(sql)) {
-        return Promise.resolve([[], 0]);
-      }
-
       if (!isWriteQuery(sql)) {
         return originalQueryRaw(sql, ...rest);
+      }
+
+      if (isAntiDeleteDml(sql)) {
+        return Promise.resolve([[], 0]);
       }
 
       if (isHighVolumeQuery(sql)) {
@@ -311,18 +314,21 @@ function applySQLiteResilience(sequelizeInstance) {
       return false;
   };
 
-  const isAntiDeleteQuery = (sql) => {
+  const isAntiDeleteDml = (sql) => {
     if (!sql || typeof sql !== "string") return false;
-    return sql.toLowerCase().includes("antideletecache");
+    const lower = sql.toLowerCase();
+    if (!lower.includes("antideletecache")) return false;
+    const trimmed = lower.trimStart();
+    return trimmed.startsWith("insert") || trimmed.startsWith("update") || trimmed.startsWith("delete");
   };
 
   sequelizeInstance.query = function serializedQuery(sql, ...rest) {
-    if (isAntiDeleteQuery(sql)) {
-      return Promise.resolve([[], 0]);
-    }
-
     if (!isWriteQuery(sql)) {
       return originalQuery(sql, ...rest);
+    }
+
+    if (isAntiDeleteDml(sql)) {
+      return Promise.resolve([[], 0]);
     }
 
     if (isHighVolumeQuery(sql)) {
@@ -354,12 +360,12 @@ function applySQLiteResilience(sequelizeInstance) {
   if (typeof sequelizeInstance.queryRaw === "function") {
     const originalQueryRaw = sequelizeInstance.queryRaw.bind(sequelizeInstance);
     sequelizeInstance.queryRaw = function serializedQueryRaw(sql, ...rest) {
-      if (isAntiDeleteQuery(sql)) {
-        return Promise.resolve([[], 0]);
-      }
-
       if (!isWriteQuery(sql)) {
         return originalQueryRaw(sql, ...rest);
+      }
+
+      if (isAntiDeleteDml(sql)) {
+        return Promise.resolve([[], 0]);
       }
 
       if (isHighVolumeQuery(sql)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix bot startup error and reconnection loop by refining the anti-delete query filter.

The `isAntiDeleteQuery` filter in `config.js` was blocking all queries containing "antideletecache", including read-only schema introspection queries (`PRAGMA TABLE_INFO`, `DESCRIBE`). This caused a `TypeError: Cannot create property 'unique' on number '0'` within Sequelize's `describeTable` and led to the bot entering a continuous reconnection loop. The fix renames the filter to `isAntiDeleteDml` and modifies it to only block INSERT/UPDATE/DELETE (DML) statements, allowing schema operations to proceed normally.

<div><a href="https://cursor.com/agents/bc-42efcd0a-e5d4-47bb-9063-0f39a8ca6400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42efcd0a-e5d4-47bb-9063-0f39a8ca6400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->