### PR TITLE
Add weather/earthquake/editor/removebg plugins, TTS and schedule refactor, Turkish group/warn updates

### DIFF
--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -727,6 +727,159 @@ Module(
 );
 
 
+const cityCodes = {
+  "01": "Adana", "02": "Adıyaman", "03": "Afyonkarahisar", "04": "Ağrı", "05": "Amasya",
+  "06": "Ankara", "07": "Antalya", "08": "Artvin", "09": "Aydın", "10": "Balıkesir",
+  "11": "Bilecik", "12": "Bingöl", "13": "Bitlis", "14": "Bolu", "15": "Burdur",
+  "16": "Bursa", "17": "Çanakkale", "18": "Çankırı", "19": "Çorum", "20": "Denizli",
+  "21": "Diyarbakır", "22": "Edirne", "23": "Elazığ", "24": "Erzincan", "25": "Erzurum",
+  "26": "Eskişehir", "27": "Gaziantep", "28": "Giresun", "29": "Gümüşhane", "30": "Hakkari",
+  "31": "Hatay", "32": "Isparta", "33": "Mersin", "34": "İstanbul", "35": "İzmir",
+  "36": "Kars", "37": "Kastamonu", "38": "Kayseri", "39": "Kırklareli", "40": "Kırşehir",
+  "41": "Kocaeli", "42": "Konya", "43": "Kütahya", "44": "Malatya", "45": "Manisa",
+  "46": "Kahramanmaraş", "47": "Mardin", "48": "Muğla", "49": "Muş", "50": "Nevşehir",
+  "51": "Niğde", "52": "Ordu", "53": "Rize", "54": "Sakarya", "55": "Samsun", "56": "Siirt",
+  "57": "Sinop", "58": "Sivas", "59": "Tekirdağ", "60": "Tokat", "61": "Trabzon",
+  "62": "Tunceli", "63": "Şanlıurfa", "64": "Uşak", "65": "Van", "66": "Yozgat",
+  "67": "Zonguldak", "68": "Aksaray", "69": "Bayburt", "70": "Karaman", "71": "Kırıkkale",
+  "72": "Batman", "73": "Şırnak", "74": "Bartın", "75": "Ardahan", "76": "Iğdır",
+  "77": "Yalova", "78": "Karabük", "79": "Kilis", "80": "Osmaniye", "81": "Düzce",
+};
+
+const turkishCities = Object.values(cityCodes).map((city) => city.toLowerCase());
+
+async function sendWeatherMessage(m, message) {
+  try {
+    await m.sendReply(message);
+  } catch (error) {
+    console.error("Mesaj gönderme hatası:", error);
+  }
+}
+
+function isTurkishCity(cityName) {
+  return turkishCities.includes(cityName.toLowerCase());
+}
+
+function normalizeTurkishCharacters(text) {
+  return text
+    .replace(/ö/g, "o")
+    .replace(/Ö/g, "O")
+    .replace(/ü/g, "u")
+    .replace(/Ü/g, "U")
+    .replace(/ş/g, "s")
+    .replace(/Ş/g, "S")
+    .replace(/ı/g, "i")
+    .replace(/İ/g, "I")
+    .replace(/ç/g, "c")
+    .replace(/Ç/g, "C")
+    .replace(/ğ/g, "g")
+    .replace(/Ğ/g, "G");
+}
+
+function getTimeBasedEmoji(temp) {
+  const turkeyTime = new Date().toLocaleString("en-US", { timeZone: "Europe/Istanbul" });
+  const turkeyDate = new Date(turkeyTime);
+  const hour = turkeyDate.getHours();
+
+  if (hour >= 22 || hour < 5) {
+    if (temp <= 0) return { start: "🌙", end: "❄️" };
+    if (temp <= 10) return { start: "🌙", end: "🥶" };
+    if (temp <= 20) return { start: "🌙", end: "😴" };
+    return { start: "🌙", end: "🔥" };
+  }
+  if (hour >= 5 && hour < 12) {
+    if (temp <= 0) return { start: "🌅", end: "❄️" };
+    if (temp <= 10) return { start: "🌅", end: "🥶" };
+    if (temp <= 20) return { start: "🌅", end: "☕" };
+    return { start: "🌅", end: "☀️" };
+  }
+  if (hour >= 12 && hour < 19) {
+    if (temp <= 0) return { start: "☀️", end: "❄️" };
+    if (temp <= 10) return { start: "🌤️", end: "🧥" };
+    if (temp <= 20) return { start: "☀️", end: "😊" };
+    if (temp <= 30) return { start: "☀️", end: "🔥" };
+    return { start: "🔥", end: "🥵" };
+  }
+  if (hour >= 19 && hour < 22) {
+    if (temp <= 0) return { start: "🌆", end: "❄️" };
+    if (temp <= 10) return { start: "🌆", end: "🧥" };
+    if (temp <= 20) return { start: "🌆", end: "😌" };
+    return { start: "🌆", end: "🔥" };
+  }
+  return { start: "🌡️", end: "📍" };
+}
+
+Module(
+  {
+    pattern: "hava ?(.*)",
+    fromMe: false,
+    desc: "Hava durumu bilgisi gönderir.",
+    use: "utility",
+  },
+  async (m, match) => {
+    const restrictedGroupId = "905396978235-1601666238@g.us";
+    if (m.jid === restrictedGroupId) {
+      await sendWeatherMessage(m, "❗ *Bu komut sadece sohbet grubunda kullanılabilir!*");
+      return;
+    }
+
+    const queriedCity = match[1]?.trim();
+    if (!queriedCity) {
+      await sendWeatherMessage(m, "❗ Lütfen bir şehir adı belirtiniz.");
+      return;
+    }
+
+    const normalizedCity = normalizeTurkishCharacters(queriedCity);
+    const city = cityCodes[normalizedCity] || normalizedCity;
+
+    try {
+      const API_KEY = "3df525a18b9fc5c3a689ac0456be979c";
+      const encodedCity = encodeURIComponent(city);
+      const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodedCity}&appid=${API_KEY}&units=metric&lang=tr`;
+      const response = await axios.get(apiUrl);
+      const data = response.data;
+
+      if (data.cod === "404" || data.cod === 404) {
+        await sendWeatherMessage(
+          m,
+          `❌ Konum bulunamadı: ${queriedCity}\n💬 *Örnek: _.hava şehir veya ilçe veya mahalle_*`
+        );
+        return;
+      }
+
+      const { main, wind, weather } = data;
+      const temp = Math.round(main.temp);
+      const humidity = main.humidity;
+      const windSpeed = wind.speed;
+      const description = weather[0].description;
+      const cityName = data.name;
+      const emojiPair = getTimeBasedEmoji(temp);
+      const cityBadge = isTurkishCity(cityName) ? " 🇹🇷" : "";
+
+      await sendWeatherMessage(
+        m,
+        `📍 *${cityName}${cityBadge}* için hava durumu:\n` +
+          `${emojiPair.start} Sıcaklık: *${temp}°C* - ${description} ${emojiPair.end}\n` +
+          `💧 Nem: *%${humidity}*\n` +
+          `💨 Rüzgar: *${windSpeed} m/s*`
+      );
+    } catch (error) {
+      if (error.response?.status === 404) {
+        await sendWeatherMessage(
+          m,
+          "❌ Belirtilen konum bulunamadı!\n💬 *Örnek: _.hava şehir veya ilçe veya mahalle_*"
+        );
+      } else {
+        await sendWeatherMessage(
+          m,
+          "⚠️ Hava durumu bilgisi alınırken bir hata oluştu. Tekrar deneyiniz."
+        );
+      }
+    }
+  }
+);
+
+
 const currencyMap = {
   'dolar': 'USD', 'tl': 'TRY', 'euro': 'EUR', 'sterlin': 'GBP', 'frank': 'CHF',
   'yen': 'JPY', 'yuan': 'CNY', 'rupi': 'INR', 'ruble': 'RUB', 'real': 'BRL',

--- a/plugins/converters.js
+++ b/plugins/converters.js
@@ -15,6 +15,7 @@ const config = require("../config");
 const axios = require("axios");
 const fileType = require("file-type");
 const { getTempPath, getTempSubdir } = require("../core/helpers");
+const { badWords } = require("./utils/censor");
 
 /** TTS için metni google-tts-api limitine (200 karakter) uygun hale getirir. */
 function prepareTtsText(text) {
@@ -542,6 +543,129 @@ Module(
     });
   }
 );
+
+Module(
+  {
+    pattern: "ses ?(.*)",
+    fromMe: false,
+    desc: Lang.TTS_DESC,
+    use: "utility",
+  },
+  async (message, match) => {
+    if (!message.isGroup) return await message.sendReply(Lang.GROUP_COMMAND);
+
+    const query = match[1] || message.reply_message?.text;
+    if (!query) {
+      const usageText = `🎙️ *Sesli Mesaj Aracı*
+📝 *Kullanım:*
+.ses <metin>
+.ses /cinsiyet <metin>
+.ses /dil <metin>
+.ses /hız <metin>
+🔧 *Seçenekler:*
+- */sage* - Ses tonu seçimi
+- */erkek* veya */e* - Erkek sesi
+- */kadın* veya */k* - Kadın sesi
+- */tr, /en, /es* - Dil seçimi
+- */1.5, /2.0* - Hız ayarı (0.5-2.0)
+🎤 *Ses Tonları:*
+/nova, /alloy, /ash, /coral, /echo, /fable, /onyx, /sage, /shimmer
+📌 *Örnekler:*
+.ses Naber canım
+.ses /sage Nasıl gidiyor?
+.ses /erkek Nasılsın?
+.ses /k Hava çok güzel
+.ses /en /1.2 How are you
+.ses /e /1.5 Hızlı konuş
+💡 *Not:* Bir mesajı yanıtlayarak da kullanabilirsiniz.`;
+      return await message.sendReply(usageText);
+    }
+
+    let ttsMessage = query;
+    let LANG = "tr";
+    let SPEED = 0.9;
+    let VOICE = "coral";
+
+    if (/\/erkek\b|\/e\b/i.test(ttsMessage)) {
+      VOICE = "ash";
+      ttsMessage = ttsMessage.replace(/\/erkek\b|\/e\b/gi, "").trim();
+    } else if (/\/kadın\b|\/k\b/i.test(ttsMessage)) {
+      VOICE = "nova";
+      ttsMessage = ttsMessage.replace(/\/kadın\b|\/k\b/gi, "").trim();
+    }
+
+    const langMatch = ttsMessage.match(/\/(tr|en|es|fr|de|it|pt|ru|ja|ko|zh)\b/i);
+    if (langMatch) {
+      LANG = langMatch[1].toLowerCase();
+      ttsMessage = ttsMessage.replace(langMatch[0], "").trim();
+    }
+
+    const speedMatch = ttsMessage.match(/\/([0-9]+\.?[0-9]*)\b/);
+    if (speedMatch) {
+      const speed = parseFloat(speedMatch[1]);
+      if (speed >= 0.5 && speed <= 2.0) {
+        SPEED = speed;
+        ttsMessage = ttsMessage.replace(speedMatch[0], "").trim();
+      }
+    }
+
+    const voiceMatch = ttsMessage.match(/\/(nova|alloy|ash|coral|echo|fable|onyx|sage|shimmer)\b/i);
+    if (voiceMatch) {
+      VOICE = voiceMatch[1].toLowerCase();
+      ttsMessage = ttsMessage.replace(voiceMatch[0], "").trim();
+    }
+
+    ttsMessage = ttsMessage.replace(/\s+/g, " ").trim();
+    if (!ttsMessage) {
+      return await message.sendReply("❌ Seslendirilecek metin bulunamadı.");
+    }
+
+    function makeBadWordRegex(word) {
+      const pattern = word
+        .replace(/a/g, "[a4@]")
+        .replace(/i/g, "[i1!İî]")
+        .replace(/o/g, "[o0ö]")
+        .replace(/u/g, "[uü]")
+        .replace(/s/g, "[s5$ş]")
+        .replace(/c/g, "[cç]")
+        .replace(/g/g, "[gğ9]")
+        .replace(/e/g, "[e3]")
+        .replace(/\s+|\./g, "(\\s|\\.|-|_)*");
+      return new RegExp(`\\b${pattern}\\b`, "iu");
+    }
+
+    const filterRegexes = badWords.map(makeBadWordRegex);
+    const containsBadWord = filterRegexes.some((rx) => rx.test(ttsMessage));
+    if (containsBadWord) {
+      return await message.sendReply("🚫 OPS! Seslendirme hatası.");
+    }
+
+    try {
+      let audio;
+      try {
+        const ttsResult = await aiTTS(ttsMessage, VOICE, SPEED.toFixed(2));
+        if (ttsResult.url) {
+          audio = { url: ttsResult.url };
+        } else {
+          throw new Error(ttsResult.error || "YZ Ses Sunucu Hatası!");
+        }
+      } catch (e) {
+        console.log("YZ TTS hatası, Google TTS'e geçiliyor:", e.message);
+        audio = await gtts(ttsMessage, LANG);
+      }
+
+      await message.client.sendMessage(message.jid, {
+        audio,
+        mimetype: "audio/mpeg",
+        ptt: true,
+      });
+    } catch (error) {
+      console.error("TTS Hatası:", error);
+      await message.sendReply("_" + Lang.TTS_ERROR + "_");
+    }
+  }
+);
+
 Module(
   {
     pattern: "doc ?(.*)",

--- a/plugins/earthquake.js
+++ b/plugins/earthquake.js
@@ -1,0 +1,159 @@
+const axios = require("axios");
+const fs = require("fs/promises");
+const path = require("path");
+const { Module } = require("../main");
+const { MODE } = require("../config");
+
+const auto = MODE === "public" ? false : true;
+const CHECK_INTERVAL = 90000;
+const LAST_EARTHQUAKE_FILE_PATH = path.join(__dirname, "lastEarthquake.txt");
+
+let intervalId = null;
+let lastEarthquake = {};
+
+(async () => {
+  try {
+    const data = await fs.readFile(LAST_EARTHQUAKE_FILE_PATH, "utf-8");
+    if (data) lastEarthquake = JSON.parse(data);
+  } catch {
+    console.log("No previous earthquake data found, starting fresh.");
+  }
+})();
+
+const getEarthquakeData = async (timeout = 30000, retryCount = 0) => {
+  try {
+    const response = await axios.get(
+      "https://api.orhanaydogdu.com.tr/deprem/kandilli/live?limit=1",
+      { timeout }
+    );
+    return { earthquakes: response.data.result };
+  } catch (err) {
+    console.error(`Error fetching earthquake data: ${err.message}`);
+    if (retryCount < 10) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      return getEarthquakeData(timeout, retryCount + 1);
+    }
+    throw err;
+  }
+};
+
+const formatKandilliDate = (dateTime) => {
+  if (!dateTime) return "Veri yok";
+  const [datePart, timePart] = dateTime.split(" ");
+  const [year, month, day] = datePart.split("-");
+  return `${day}.${month}.${year} ${timePart}`;
+};
+
+const normalize = (text = "") =>
+  text
+    .toLowerCase()
+    .replace(/ı/g, "i")
+    .replace(/ğ/g, "g")
+    .replace(/ü/g, "u")
+    .replace(/ş/g, "s")
+    .replace(/ö/g, "o")
+    .replace(/ç/g, "c");
+
+const listAllEarthquakes = async (m, { limit, region } = {}) => {
+  try {
+    let url = "https://api.orhanaydogdu.com.tr/deprem/kandilli/live";
+    if (limit && Number.isInteger(limit)) url += `?limit=${limit}`;
+
+    const response = await axios.get(url, { timeout: 30000 });
+    const { metadata, result: earthquakes } = response.data;
+
+    let message = "🌍 *SON DEPREMLER:*\n\n";
+    if (metadata) {
+      message += `📅 Zaman: *${formatKandilliDate(metadata.date_starts)}*\n`;
+      message += `🧮 Toplam Deprem Sayısı: *${metadata.count}*\n`;
+    }
+
+    let filtered = earthquakes;
+    if (region) {
+      const key = normalize(region);
+      filtered = earthquakes.filter((eq) => normalize(eq.title || "").includes(key));
+      message += `\n📍 Şehir filtresi: *${region}*\n`;
+    }
+
+    message += `📊 Gösterilen deprem sayısı: *${filtered.length}*\n\n`;
+
+    if (!filtered.length) {
+      await m.send(`${message}⚠️ Eşleşen deprem kaydı bulunamadı.`);
+      return;
+    }
+
+    filtered.forEach((earthquake, index) => {
+      const time = formatKandilliDate(earthquake.date_time);
+      message += `${index + 1}. 📍 Konum: *${earthquake.title}*\n`;
+      message += `🌟 Büyüklük: *${earthquake.mag}*\n`;
+      message += `⏰ Zaman: *${time}*\n\n`;
+    });
+
+    await m.send(message);
+  } catch (err) {
+    await m.send(`❌ HATA: ${err.message}`);
+  }
+};
+
+Module(
+  {
+    pattern: "sondepremler ?(.*)",
+    fromMe: auto,
+    desc: "Türkiye genelinde gerçekleşen son depremleri listeler.",
+    use: "utility",
+  },
+  async (m, match) => {
+    const rawArgs = (match && match[1] ? match[1] : "").trim();
+    const args = rawArgs.split(/\s+/).filter(Boolean);
+
+    let limit = null;
+    const regionParts = [];
+
+    args.forEach((arg) => {
+      if (/^\d+$/.test(arg) && !limit) {
+        limit = parseInt(arg, 10);
+      } else {
+        regionParts.push(arg);
+      }
+    });
+
+    const region = regionParts.length ? regionParts.join(" ") : null;
+    await listAllEarthquakes(m, { limit, region });
+  }
+);
+
+Module(
+  {
+    pattern: "sondeprem",
+    fromMe: auto,
+    desc: "Son deprem kaydını gösterir.",
+    use: "utility",
+    dontAddCommandList: true,
+  },
+  async (m) => {
+    try {
+      const { earthquakes } = await getEarthquakeData();
+      const latest = earthquakes?.[0];
+      if (!latest) return await m.send("⚠️ Son deprem verisi alınamadı.");
+
+      const info =
+        `🌍 *SON DEPREM*\n\n` +
+        `📍 Konum: *${latest.title}*\n` +
+        `🌟 Büyüklük: *${latest.mag}*\n` +
+        `⏰ Zaman: *${formatKandilliDate(latest.date_time)}*`;
+      await m.send(info);
+    } catch (err) {
+      await m.send(`❌ HATA: ${err.message}`);
+    }
+  }
+);
+
+module.exports = {
+  getEarthquakeData,
+  formatKandilliDate,
+  normalize,
+  listAllEarthquakes,
+  CHECK_INTERVAL,
+  intervalId,
+  lastEarthquake,
+};

--- a/plugins/editor.js
+++ b/plugins/editor.js
@@ -1,0 +1,128 @@
+const { Module } = require("../main");
+const { MODE } = require("../config");
+const { getBuffer } = require("./utils");
+const { uploadToImgbb } = require("./utils/upload");
+
+const x = MODE == "public" ? false : true;
+
+const EFFECTS = [
+  { command: "blur", desc: "Fotoğrafı bulanıklaştırır.", route: "filter/blur" },
+  { command: "pixelate", desc: "Fotoğrafı pikselleştirir.", route: "filter/pixelate" },
+  { command: "blue", desc: "Mavi filtre uygular.", route: "filter/blue" },
+  { command: "blurple", desc: "Blurple filtre uygular.", route: "filter/blurple" },
+  { command: "blurple2", desc: "Blurple v2 filtre uygular.", route: "filter/blurple2" },
+  { command: "brightness", desc: "Parlaklık filtresi uygular.", route: "filter/brightness" },
+  { command: "color", desc: "Renk doygunluğu filtresi uygular.", route: "filter/color" },
+  { command: "green", desc: "Yeşil filtre uygular.", route: "filter/green" },
+  { command: "bw", desc: "Siyah-beyaz efekti uygular.", route: "filter/greyscale" },
+  { command: "invert", desc: "Ters çevirme efekti uygular.", route: "filter/invert" },
+  {
+    command: "2invert",
+    desc: "Ters + gri çevirme efektini uygular.",
+    route: "filter/invertgreyscale",
+  },
+  { command: "red", desc: "Kırmızı filtre uygular.", route: "filter/red" },
+  { command: "golden", desc: "Altın (sepia) filtresi uygular.", route: "filter/sepia" },
+  { command: "threshold", desc: "Eşik filtresi uygular.", route: "filter/threshold" },
+  { command: "rainbow", desc: "LGBT gökkuşağı efekti uygular.", route: "misc/lgbt" },
+  { command: "gay", desc: "Gay overlay efekti uygular.", route: "overlay/gay" },
+  { command: "horny", desc: "Ateşli kart üretir.", route: "misc/horny" },
+  { command: "simpcard", desc: "Simp kartı üretir.", route: "misc/simpcard" },
+  { command: "circle", desc: "Dairesel avatar efekti uygular.", route: "misc/circle" },
+  { command: "heart", desc: "Kalp temalı efekt uygular.", route: "misc/heart" },
+  { command: "glass", desc: "Cam overlay efekti uygular.", route: "overlay/glass" },
+  { command: "wasted", desc: "GTA Wasted efekti uygular.", route: "overlay/wasted" },
+  { command: "passed", desc: "GTA Mission Passed efekti uygular.", route: "overlay/passed" },
+  { command: "jail", desc: "Hapishane overlay efekti uygular.", route: "overlay/jail" },
+  { command: "comrade", desc: "Comrade overlay efekti uygular.", route: "overlay/comrade" },
+  { command: "triggered", desc: "Triggered overlay efekti uygular.", route: "overlay/triggered" },
+];
+
+const list =
+  "```" +
+  [
+    "╔════════════════",
+    "║ 📸 FOTOĞRAF DÜZENLEME KOMUTLARI 🎨",
+    "╚═══════════════ Herhangi bir fotoğrafa yanıt vererek kullanabilirsiniz.",
+    "",
+    "🔹 *Filtreler:* .blur .pixelate .blue .blurple .blurple2 .brightness .color .green .bw .invert .2invert .red .golden .threshold",
+    "🔹 *Misc:* .rainbow .horny .simpcard .circle .heart",
+    "🔹 *Overlay:* .gay .glass .wasted .passed .jail .comrade .triggered",
+  ].join("\n") +
+  "\n```";
+
+function buildCandidateUrls(route, imageUrl) {
+  const encoded = encodeURIComponent(imageUrl);
+  const base = `https://api.some-random-api.com/canvas/${route}`;
+  if (route.startsWith("overlay/")) {
+    return [`${base}?avatar=${encoded}`, `${base}?image=${encoded}`];
+  }
+  return [`${base}?avatar=${encoded}`, `${base}?image=${encoded}`];
+}
+
+async function applyEffect(message, route) {
+  if (!message.reply_message || !message.reply_message.image) {
+    return await message.sendReply("❗️ *Bir fotoğrafa yanıt vererek yazınız.*");
+  }
+
+  const imagePath = await message.reply_message.download();
+  const upload = await uploadToImgbb(imagePath);
+  const link = upload?.url;
+
+  if (!link) {
+    return await message.sendReply("❌ *Görsel yüklenemedi. Tekrar deneyin.*");
+  }
+
+  const urls = buildCandidateUrls(route, link);
+  let buffer;
+  let lastError;
+
+  for (const url of urls) {
+    try {
+      buffer = await getBuffer(url);
+      if (buffer?.length) break;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  if (!buffer) {
+    console.error("Editor effect failed:", route, lastError?.message || lastError);
+    return await message.sendReply(
+      "❌ *Efekt uygulanamadı. API şu an yanıt vermiyor olabilir.*"
+    );
+  }
+
+  return await message.sendMessage(buffer, "image");
+}
+
+Module(
+  {
+    pattern: "editör",
+    fromMe: x,
+    desc: "Fotoğraf düzenleme araçlarını getirir.",
+    use: "utility",
+  },
+  async (message) => {
+    await message.sendReply(list);
+  }
+);
+
+function registerEffect(command, desc, route) {
+  Module(
+    {
+      pattern: `${command} ?(.*)`,
+      fromMe: x,
+      dontAddCommandList: true,
+      desc,
+      use: "utility",
+    },
+    async (message) => {
+      await applyEffect(message, route);
+    }
+  );
+}
+
+for (const effect of EFFECTS) {
+  registerEffect(effect.command, effect.desc, effect.route);
+}

--- a/plugins/fun-tests.js
+++ b/plugins/fun-tests.js
@@ -1,0 +1,136 @@
+const { Module } = require("../main");
+const { mentionjid } = require("./utils");
+const { getString } = require("./utils/lang");
+
+const Lang = getString("group");
+
+const getTargetUser = (message) => message.mention?.[0] || message.reply_message?.jid;
+const randomPercent = () => Math.floor(Math.random() * 100) + 1;
+
+async function runSingleRateCommand(message, { introText, resultText }) {
+  if (!message.isGroup) return await message.sendReply(Lang.GROUP_COMMAND);
+
+  const user = getTargetUser(message);
+  if (!user) return await message.sendReply(Lang.NEED_USER);
+
+  await message.client.sendMessage(message.jid, {
+    text: `${mentionjid(user)} ${introText}`,
+    mentions: [user],
+  });
+
+  return await message.send(resultText(randomPercent()));
+}
+
+Module(
+  {
+    pattern: "testgay ?(.*)",
+    fromMe: false,
+    use: "group",
+    desc: "Etiketlediğiniz üyenin gaylik yüzdesini ölçer.",
+  },
+  async (message) => {
+    await runSingleRateCommand(message, {
+      introText: "üyesinin *Gay* olma ihtimalini hesaplıyorum... 🧐",
+      resultText: (percent) => `🏳️‍🌈 Senin *Gaylik* yüzden: *%${percent}!*`,
+    });
+  }
+);
+
+Module(
+  {
+    pattern: "testlez ?(.*)",
+    fromMe: false,
+    use: "group",
+    desc: "Etiketlediğiniz üyenin lezlik yüzdesini ölçer.",
+  },
+  async (message) => {
+    await runSingleRateCommand(message, {
+      introText: "üyesinin *Lez* olma ihtimalini hesaplıyorum... 🧐",
+      resultText: (percent) => `👩🏻‍❤️‍👩🏼 Senin *Lezlik* yüzden: *%${percent}!*`,
+    });
+  }
+);
+
+Module(
+  {
+    pattern: "testprenses ?(.*)",
+    fromMe: false,
+    use: "group",
+    desc: "Etiketlediğiniz üyenin prenseslik seviyesini ölçer.",
+  },
+  async (message) => {
+    await runSingleRateCommand(message, {
+      introText: "üyesinin *Prenses* olma ihtimalini hesaplıyorum... 🧐",
+      resultText: (percent) => `🤭 Senin *Prenseslik* yüzden: *%${percent}!* 👸🏻`,
+    });
+  }
+);
+
+Module(
+  {
+    pattern: "testregl ?(.*)",
+    fromMe: false,
+    use: "group",
+    desc: "Etiketlediğiniz üyenin Regl olma ihtimalini ölçer.",
+  },
+  async (message) => {
+    await runSingleRateCommand(message, {
+      introText: "üyesinin *Regl* olma ihtimalini hesaplıyorum... 🧐",
+      resultText: (percent) => `🩸 Senin *Regl* yüzden: *%${percent}!* 😆`,
+    });
+  }
+);
+
+Module(
+  {
+    pattern: "testinanç ?(.*)",
+    fromMe: false,
+    use: "group",
+    desc: "Etiketlediğiniz üyenin inanç seviyesini ölçer.",
+  },
+  async (message) => {
+    await runSingleRateCommand(message, {
+      introText: "üyesinin *İnanç* seviyesini hesaplıyorum... 🧐",
+      resultText: (percent) => `🛐 Senin *İnanç* yüzden: *%${percent}!*`,
+    });
+  }
+);
+
+Module(
+  {
+    pattern: "aşkölç ?(.*)",
+    fromMe: false,
+    use: "group",
+    desc: "İki kişi arasındaki aşk yüzdesini ölçer.",
+  },
+  async (message, match) => {
+    if (!message.isGroup) return await message.sendReply(Lang.GROUP_COMMAND);
+
+    const percentage = Math.floor(Math.random() * 101);
+    const mentioned = message.mention || [];
+
+    if (mentioned.length > 0) {
+      if (mentioned.length < 2) {
+        return await message.sendReply("❗️ 2 isim yazmalısınız!");
+      }
+
+      const [u1, u2] = mentioned;
+      return await message.client.sendMessage(message.jid, {
+        text:
+          `🔥 ${mentionjid(u1)} ve ${mentionjid(u2)} ` +
+          `arasındaki aşk yüzdesi: *%${percentage}!* ❤️‍🔥`,
+        mentions: [u1, u2],
+      });
+    }
+
+    const parts = (match[1] || "").trim().split(/ +/).slice(0, 2);
+    if (parts.length !== 2) {
+      return await message.sendReply("❗️ 2 isim yazmalısınız!");
+    }
+
+    const [name1, name2] = parts;
+    return await message.send(
+      `🔥 *${name1}* ve *${name2}* arasındaki aşk yüzdesi: *%${percentage}!* ❤️‍🔥`
+    );
+  }
+);

--- a/plugins/group.js
+++ b/plugins/group.js
@@ -1,9 +1,11 @@
 const { getString } = require("./utils/lang");
 const Lang = getString("group");
 const { loadBaileys } = require("../core/helpers");
+let delay, generateWAMessageFromContent, proto;
+
 const baileysPromise = loadBaileys()
   .then((baileys) => {
-    ({ delay } = baileys);
+    ({ delay, generateWAMessageFromContent, proto } = baileys);
   })
   .catch((err) => {
     console.error("Baileys yüklenemedi:", err.message);
@@ -15,6 +17,7 @@ const config = require("../config");
 const { Module } = require("../main");
 const fs = require("fs");
 const path = require("path");
+const axios = require("axios");
 const {
   fetchFromStore,
   getFullMessage,
@@ -22,6 +25,43 @@ const {
 } = require("../core/store");
 const { setVar } = require("./manage");
 var handler = HANDLERS !== "false" ? HANDLERS.split("")[0] : "";
+
+
+async function sendBanAudio(message) {
+  const fsp = fs.promises;
+  const tempDir = path.join(__dirname, "temp");
+  const audioPath = path.join(tempDir, "ban.mp3");
+
+  try {
+    if (!fs.existsSync(tempDir)) {
+      await fsp.mkdir(tempDir, { recursive: true });
+    }
+
+    if (!fs.existsSync(audioPath)) {
+      const response = await axios.get("https://dl.sndup.net/bq7y/Ban.mp3", {
+        responseType: "stream",
+      });
+
+      await new Promise((resolve, reject) => {
+        const writer = fs.createWriteStream(audioPath);
+        response.data.pipe(writer);
+        writer.on("finish", resolve);
+        writer.on("error", reject);
+      });
+    }
+
+    const stream = fs.createReadStream(audioPath);
+    try {
+      await message.send({ stream }, "audio");
+    } finally {
+      stream.destroy();
+    }
+  } catch (err) {
+    console.error("Ban sesini gönderirken hata:", err);
+    await message.sendReply("⚠️ _Ban sesi gönderilemedi, işlem devam ediyor._");
+  }
+}
+
 
 Module(
   {
@@ -122,6 +162,115 @@ Module(
     }
   }
 );
+
+Module(
+  {
+    pattern: "at ?(.*)",
+    fromMe: false,
+    desc: Lang.KICK_DESC,
+    use: "group",
+  },
+  async (message, match) => {
+    if (!message.isGroup) {
+      return await message.sendReply(Lang.GROUP_COMMAND);
+    }
+
+    const userIsAdmin = await isAdmin(message, message.sender);
+    if (!userIsAdmin) {
+      return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
+    }
+
+    const botIsAdmin = await isAdmin(message);
+    if (!botIsAdmin) {
+      return await message.sendReply("❌ _Bot'un üyeleri atabilmesi için yönetici olması gerekiyor!_");
+    }
+
+    let usersToKick = [];
+    if (message.mention && message.mention.length > 0) {
+      usersToKick = message.mention;
+    } else if (message.reply_message) {
+      const replyUser =
+        message.reply_message.participant ||
+        message.reply_message.sender ||
+        message.reply_message.jid;
+      if (replyUser) {
+        usersToKick = [replyUser];
+      }
+    }
+
+    if (!usersToKick.length) {
+      return await message.sendReply(
+        "❌ _Lütfen bir üye etiketleyin veya bir mesaja yanıt verin!_"
+      );
+    }
+
+    const botId = message.client.user.id.split(":")[0] + "@s.whatsapp.net";
+    let canKickAnyone = false;
+    let adminUsers = [];
+
+    for (const user of usersToKick) {
+      if (user === botId) {
+        continue;
+      }
+      try {
+        const isTargetAdmin = await isAdmin(message, user);
+        if (isTargetAdmin) {
+          adminUsers.push(user);
+        } else {
+          canKickAnyone = true;
+        }
+      } catch (error) {
+        console.error("Admin kontrolü hatası:", user, error);
+        canKickAnyone = true;
+      }
+    }
+
+    if (!canKickAnyone) {
+      if (adminUsers.length > 0) {
+        return await message.sendReply(
+          `❌ _Belirtilen kişi${adminUsers.length > 1 ? "lar" : ""} yönetici olduğu için atılamaz!_`
+        );
+      }
+      return await message.sendReply("❌ _Bot kendisini gruptan atamaz!_");
+    }
+
+    await sendBanAudio(message);
+
+    for (const user of usersToKick) {
+      try {
+        if (user === botId) {
+          await message.sendReply("❌ _Bot kendisini gruptan atamaz!_");
+          continue;
+        }
+        const isTargetAdmin = await isAdmin(message, user);
+        if (isTargetAdmin) {
+          await message.sendReply(
+            `❌ ${mentionjid(user)} _bir yönetici olduğu için atılamaz!_`,
+            { mentions: [user] }
+          );
+          continue;
+        }
+
+        await message.client.sendMessage(message.jid, {
+          text: mentionjid(user) + Lang.KICKED,
+          mentions: [user],
+        });
+        await message.client.groupParticipantsUpdate(message.jid, [user], "remove");
+
+        if (usersToKick.length > 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1500));
+        }
+      } catch (error) {
+        console.error("Üye atılırken hata:", error);
+        await message.sendReply(`❌ ${mentionjid(user)} _atılırken bir hata oluştu!_`, {
+          mentions: [user],
+        });
+      }
+    }
+  }
+);
+
+
 Module(
   {
     pattern: "add ?(.*)",
@@ -1108,7 +1257,7 @@ const loadKaraListe = () => {
   }
 };
 const saveKaraListe = async (liste) => {
-  await setVar("DUYURU_LISTE_DISI", liste.join(","));
+  await setVar("DUYURU_KARA_LISTE", liste.join(","));
 };
 
 Module(
@@ -1134,10 +1283,11 @@ Module(
     const input = match[1]?.trim() || "";
     const arg = input.toLowerCase();
 
-    if (arg.startsWith("grup")) {
+    if (arg.startsWith("grup") || arg.startsWith("karalist")) {
       const parts = input.split(" ");
-      const cmd = parts[1]?.toLowerCase();
-      const jid = parts[2]?.trim();
+      const cmdOffset = parts[0]?.toLowerCase() === "karalist" ? 0 : 1;
+      const cmd = parts[cmdOffset + 1]?.toLowerCase();
+      const jid = parts[cmdOffset + 2]?.trim();
       const liste = loadKaraListe();
       if (cmd === "filtrele" && jid) {
         if (liste.includes(jid)) return message.sendReply("_Bu grup zaten kara listede._");
@@ -1293,6 +1443,13 @@ Module(
       );
     }
 
+    await baileysPromise;
+    if (!generateWAMessageFromContent || !proto) {
+      return await message.sendReply(
+        "_❌ Bot bileşenleri henüz yüklenmedi, lütfen biraz bekleyip tekrar deneyin._"
+      );
+    }
+
     const input = match[1] ? match[1].trim().toLowerCase() : "";
     let durationSeconds;
     let durationText;
@@ -1396,44 +1553,123 @@ Module(
   }
 );
 
+
+function parseSarrafiye(html) {
+  const results = {};
+  const rowRegex = /<tr[^>]*>\s*<td[^>]*>(.*?)<\/td>\s*<td[^>]*>([\d.,]+)<\/td>\s*<td[^>]*>([\d.,]+)<\/td>\s*<td[^>]*>(.*?)<\/td>/gi;
+  let match;
+  while ((match = rowRegex.exec(html)) !== null) {
+    const name = match[1]
+      .replace(/<[^>]+>/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    results[name] = {
+      buy: match[2],
+      sell: match[3],
+      change: match[4].replace("%", "").trim(),
+    };
+  }
+  return results;
+}
+
 Module(
-  { pattern: 'etiket', use: 'group', fromMe: false, desc: 'Tüm üyeleri etiketler.' },
+  {
+    pattern: "altın ?(.*)",
+    fromMe: false,
+    desc: "Güncel altın fiyatlarını gösterir",
+    use: "utility",
+  },
   async (message) => {
-    const userIsAdmin = await isAdmin(message, message.sender);
-    if (!userIsAdmin) return await message.sendReply('❌ _Üzgünüm! Öncelikle yönetici olmalısınız._');
-    if (!message.isGroup) return await message.sendReply(Lang.GROUP_COMMAND);
+    const loading = await message.send("🔄 _Altın fiyatlarına bakıyorum..._");
 
-    const target = message.jid;
-    const group = await message.client.groupMetadata(target);
-    const allMembers = group.participants.map((participant) => participant.id);
-    let text = '✅ *Herkes başarıyla etiketlendi!*';
+    try {
+      const { data: html } = await axios.get("https://www.sarrafiye.net/piyasa/altin.html", {
+        timeout: 15000,
+        headers: {
+          "User-Agent": "Mozilla/5.0",
+        },
+      });
+      const data = parseSarrafiye(html);
+      const kur = data["Kur"];
+      const gram = data["Gram Altın"];
+      const ceyrek = data["Çeyrek Altın"];
+      const yarim = data["Yarım Altın"];
+      const tam = data["Tam Ata Lira"] || data["Tam Altın"];
 
-    allMembers.forEach((jid, index) => {
-      text += `\n${index + 1}. @${jid.split('@')[0]}`;
-    });
+      if (!kur && !gram && !ceyrek && !yarim && !tam) {
+        return await message.edit(
+          "⚠️ _Altın verilerine ulaşılamadı!_\n_Kaynak yapısı değişmiş olabilir._",
+          message.jid,
+          loading.key
+        );
+      }
 
-    await message.client.sendMessage(target, {
-      text,
-      contextInfo: { mentionedJid: allMembers },
-    });
+      let text = "💰 `GÜNCEL ALTIN FİYATLARI`\n\n";
+      function addBlock(title, emoji, item, currency = "₺") {
+        if (!item) return;
+        const symbol = item.change.startsWith("-") ? "📉" : "📈";
+        text += `${emoji} *${title}*\n`;
+        text += `   💵 Alış: *${item.buy} ${currency}*\n`;
+        text += `   💰 Satış: *${item.sell} ${currency}*\n`;
+        text += `   ${symbol} Değişim: %${item.change}\n\n`;
+      }
+
+      addBlock("Kur", "📊", kur);
+      addBlock("Gram Altın", "🟡", gram);
+      addBlock("Çeyrek Altın", "🪙", ceyrek);
+      addBlock("Yarım Altın", "💎", yarim);
+      addBlock("Tam Altın", "🏅", tam);
+
+      const now = new Date().toLocaleString("tr-TR", {
+        timeZone: "Europe/Istanbul",
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      text += `_📅 ${now}_`;
+      text += "\nℹ Kaynak: _Kuyumcu Altın Verileri_";
+
+      await message.edit(text.trim(), message.jid, loading.key);
+    } catch (err) {
+      console.error("Altın modülü hata:", err?.message || err);
+      await message.edit(
+        "⚠️ _Altın verileri alınırken hata oluştu._\n_Lütfen daha sonra tekrar deneyin._",
+        message.jid,
+        loading.key
+      );
+    }
   }
 );
 
-Module(
-  { pattern: 'ytetiket', use: 'group', fromMe: false, desc: 'Tüm yöneticileri etiketler.' },
-  async (message) => {
-    if (!message.isGroup) return await message.sendReply(Lang.GROUP_COMMAND);
 
-    const target = message.jid;
-    const group = await message.client.groupMetadata(target);
-    const admins = group.participants.filter((v) => v.admin !== null).map((x) => x.id);
-    let text = '🚨 *Yöneticiler:*';
+Module({pattern: 'etiket', use: 'group', fromMe: false, desc: 'Tüm üyeleri etiketler.'}, async (message, match) => {
+  const userIsAdmin = await isAdmin(message, message.sender);
+  if (!userIsAdmin) return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
+  if (!message.isGroup) return await message.sendReply(Lang.GROUP_COMMAND);
+  const target = message.jid;
+  const group = await message.client.groupMetadata(target);
+  const allMembers = group.participants.map(participant => participant.id);
+  let text = "✅ *Herkes başarıyla etiketlendi!*";
+  allMembers.forEach((jid, index) => {
+    text += `
+${index + 1}. @${jid.split('@')[0]}`;
+  });
+  await message.client.sendMessage(target, {
+    text: text,
+    contextInfo: { mentionedJid: allMembers }
+  });
+});
 
-    admins.forEach((jid) => {
-      text += `\n@${jid.split('@')[0]}`;
+Module({pattern: 'ytetiket', use: 'group', fromMe: false, desc: 'Tüm yöneticileri etiketler.'}, async (message, match) => {
+    var target = message.jid;
+    var group = await message.client.groupMetadata(target);
+    var admins = group.participants.filter(v => v.admin !== null).map(x => x.id);
+    let text = "🚨 *Yöneticiler:*";
+      admins.forEach(jid => {
+      text += `
+@${jid.split('@')[0]}`;
     });
-
-    await message.client.sendMessage(target, { text, contextInfo: { mentionedJid: admins } });
-  }
-);
-
+    await message.client.sendMessage(target, {text: text, contextInfo: { mentionedJid: admins }});
+});

--- a/plugins/manage.js
+++ b/plugins/manage.js
@@ -1438,6 +1438,54 @@ Module(
     const foundLinks = linkDetector.detectLinks(message.message);
 
     if (foundLinks.length > 0) {
+      const isAutoDelActive = !process.env.AUTO_DEL
+        ? true
+        : process.env.AUTO_DEL.split(",").includes(message.jid);
+
+      if (isAutoDelActive) {
+        let currentGroupCode = null;
+        if (message.isGroup) {
+          try {
+            currentGroupCode = await message.client.groupInviteCode(message.jid);
+          } catch (_) {}
+        }
+
+        for (const link of foundLinks) {
+          const inviteMatch = (link || "").match(
+            /^(https?:\/\/)?chat\.whatsapp\.com\/(?:invite\/)?([a-zA-Z0-9_-]{22})(\?.*)?$/i
+          );
+          if (!inviteMatch) continue;
+
+          const botIsAdmin = await isAdmin(message);
+          const senderIsAdmin = await isAdmin(message, message.sender);
+          if (!botIsAdmin || senderIsAdmin) return;
+
+          if (currentGroupCode && inviteMatch[2] === currentGroupCode) continue;
+
+          const groupMetadata = await message.client.groupMetadata(message.jid);
+          const senderNumber = message.sender.split("@")[0];
+          const infoMessage =
+            `Saygıdeğer yöneticilerim; *${groupMetadata.subject}* grubunda ` +
+            `şu şahsı *${senderNumber}* suçüstü yakaladım. 😈
+
+🔗 ${message.message}`;
+
+          await message.client.sendMessage("120363258254647790@g.us", {
+            text: infoMessage,
+          });
+          await message.send("🚨 *Hey! Grup reklamı yapmamalısın.* 🤐");
+          try {
+            await message.client.sendMessage(message.jid, { delete: message.data.key });
+          } catch {}
+          await message.client.groupParticipantsUpdate(
+            message.jid,
+            [message.sender],
+            "remove"
+          );
+          return;
+        }
+      }
+
       const antilinkConf = await getCachedAntilinkConfig(message.jid);
 
       if (antilinkConf && antilinkConf.enabled) {

--- a/plugins/media.js
+++ b/plugins/media.js
@@ -615,7 +615,9 @@ Module(
   async (message, match) => {
     if (!message.reply_message?.audio)
       return await message.sendReply("⚠️ Bir ses dosyasına etiketleyerek yazın!");
-    if (message.reply_message.duration > 60)
+
+    var { seconds } = message.quoted.message[Object.keys(message.quoted.message)[0]];
+    if (seconds > 60)
       return await message.sendReply(
         "⚠️ *Ses çok uzun! .trim komutunu kullanıp sesi 60 saniyeye düşürmenizi öneririm.*"
       );

--- a/plugins/message-stats.js
+++ b/plugins/message-stats.js
@@ -6,132 +6,168 @@ const {
   getTopUsers,
   getGlobalTopUsers,
 } = require("../core/store");
+const fs = require("fs");
+const path = require("path");
+const axios = require("axios");
 
-function timeSince(date) {
-  if (!date) return "Hiç";
-  var seconds = Math.floor((new Date() - new Date(date)) / 1000);
-  var interval = seconds / 31536000;
-  if (interval > 1) {
-    return Math.floor(interval) + " yıl önce";
-  }
-  interval = seconds / 2592000;
-  if (interval > 1) {
-    return Math.floor(interval) + " ay önce";
-  }
-  interval = seconds / 86400;
-  if (interval > 1) {
-    return Math.floor(interval) + " gün önce";
-  }
-  interval = seconds / 3600;
-  if (interval > 1) {
-    return Math.floor(interval) + " saat önce";
-  }
-  interval = seconds / 60;
-  if (interval > 1) {
-    return Math.floor(interval) + " dakika önce";
-  }
-  return Math.floor(seconds) + " saniye önce";
+function timeSince(date, lang = "tr") {
+  if (!date) return lang === "tr" ? "Hiç" : "Never";
+  const seconds = Math.floor((new Date() - new Date(date)) / 1000);
+  let interval = Math.floor(seconds / 31536000);
+  if (interval >= 1) return lang == "tr" ? `${interval} yıl önce` : `${interval} years ago`;
+  interval = Math.floor(seconds / 2592000);
+  if (interval >= 1) return lang == "tr" ? `${interval} ay önce` : `${interval} months ago`;
+  interval = Math.floor(seconds / 604800);
+  if (interval >= 1) return lang == "tr" ? `${interval} hafta önce` : `${interval} weeks ago`;
+  interval = Math.floor(seconds / 86400);
+  if (interval >= 1) return lang == "tr" ? `${interval} gün önce` : `${interval} days ago`;
+  interval = Math.floor(seconds / 3600);
+  if (interval >= 1) return lang == "tr" ? `${interval} saat önce` : `${interval} hours ago`;
+  interval = Math.floor(seconds / 60);
+  if (interval >= 1) return lang == "tr" ? `${interval} dakika önce` : `${interval} minutes ago`;
+  return lang == "tr" ? `az önce` : `just now`;
 }
 
-function parseDuration(duration) {
-  const regex = /^(\d+)([dwmy])$/i;
-  const match = duration.match(regex);
-  if (!match) return null;
-
-  const value = parseInt(match[1]);
-  const unit = match[2].toLowerCase();
-
-  const now = new Date();
+function parseDuration(number, unit) {
+  const num = parseInt(number);
+  if (isNaN(num)) return null;
   switch (unit) {
-    case "d":
-      return new Date(now.getTime() - value * 24 * 60 * 60 * 1000);
-    case "w":
-      return new Date(now.getTime() - value * 7 * 24 * 60 * 60 * 1000);
-    case "m":
-      return new Date(now.getTime() - value * 30 * 24 * 60 * 60 * 1000);
-    case "y":
-      return new Date(now.getTime() - value * 365 * 24 * 60 * 60 * 1000);
+    case "gün":
+      return num * 24 * 60 * 60 * 1000;
+    case "hafta":
+      return num * 7 * 24 * 60 * 60 * 1000;
+    case "ay":
+      return num * 30 * 24 * 60 * 60 * 1000;
+    case "yıl":
+      return num * 365 * 24 * 60 * 60 * 1000;
     default:
       return null;
   }
 }
 
+
+async function sendBanAudio(message) {
+  const fsp = fs.promises;
+  const tempDir = path.join(__dirname, "temp");
+  const audioPath = path.join(tempDir, "ban.mp3");
+  try {
+    if (!fs.existsSync(tempDir)) {
+      await fsp.mkdir(tempDir, { recursive: true });
+    }
+    if (!fs.existsSync(audioPath)) {
+      const response = await axios.get("https://dl.sndup.net/bq7y/Ban.mp3", { responseType: "stream" });
+      await new Promise((resolve, reject) => {
+        const writer = fs.createWriteStream(audioPath);
+        response.data.pipe(writer);
+        writer.on("finish", resolve);
+        writer.on("error", reject);
+      });
+    }
+    const stream = fs.createReadStream(audioPath);
+    try {
+      await message.send({ stream }, "audio");
+    } finally {
+      stream.destroy();
+    }
+  } catch (err) {
+    console.error("Ban sesini gönderirken hata:", err);
+    await message.sendReply("⚠️ _Ban sesi gönderilemedi, işlem devam ediyor._");
+  }
+}
+
+function parseDurationInput(duration) {
+  const regex = /^(\d+)\s*(gün|hafta|ay|yıl|d|w|m|y)$/i;
+  const match = String(duration || "").trim().match(regex);
+  if (!match) return null;
+
+  const value = parseInt(match[1]);
+  const unitRaw = match[2].toLowerCase();
+  const unitMap = { d: "gün", w: "hafta", m: "ay", y: "yıl" };
+  const unit = unitMap[unitRaw] || unitRaw;
+  const ms = parseDuration(value, unit);
+  if (!ms) return null;
+  return new Date(Date.now() - ms);
+}
+
 Module(
   {
-    pattern: "msgs ?(.*)",
-    fromMe: true,
-    desc: "Grupta mesaj atan kullanıcıların mesaj sayılarını gösterir",
+    pattern: "mesajlar ?(.*)",
+    fromMe: false,
+    desc: "En az bir mesajı olan üyelerin gönderdiği mesaj sayılarını gösterir. (sayıya göre sıralanmış şekilde)",
     usage:
-      ".msgs (mesajı olan tüm üyeler)\n.msgs @etiket (belirli üye)",
+      ".mesajlar (mesaj gönderen tüm üyeler)\n.mesajlar @etiket (belirli bir üye)",
     use: "group",
   },
   async (message, match) => {
     if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu bir grup komutudur!_");
+      return await message.sendReply("⚠ _Bu komut sadece gruplarda kullanılabilir!_");
 
-    let adminAccesValidated = ADMIN_ACCESS
-      ? await isAdmin(message, message.sender)
-      : false;
-    if (message.fromOwner || adminAccesValidated) {
-      var users = (
-        await message.client.groupMetadata(message.jid)
-      ).participants.map((e) => e.id);
-      if (message.mention?.[0]) users = message.mention;
-      if (message.reply_message && !message.mention.length)
-        users = [message.reply_message?.jid];
+    var users = (await message.client.groupMetadata(message.jid)).participants.map((e) => e.id);
+    if (message.mention?.[0]) users = message.mention;
+    if (message.reply_message && !message.mention.length)
+      users = [message.reply_message?.jid];
 
-      let userStats = await fetchFromStore(message.jid);
+    let userStats = await fetchFromStore(message.jid);
+    let usersWithMessages = [];
 
-      let usersWithMessages = [];
-      for (let user of users) {
-        let userStat = userStats.find((stat) => stat.userJid === user);
-        if (userStat && userStat.totalMessages > 0) {
-          usersWithMessages.push({
-            jid: user,
-            stat: userStat,
-          });
-        }
+    for (let user of users) {
+      let userStat = userStats.find((stat) => stat.userJid === user);
+      if (userStat && userStat.totalMessages > 0) {
+        usersWithMessages.push({
+          jid: user,
+          stat: userStat,
+        });
       }
-
-      usersWithMessages.sort(
-        (a, b) => b.stat.totalMessages - a.stat.totalMessages
-      );
-
-      if (usersWithMessages.length === 0) {
-        return await message.sendReply("_❌ Veritabanında mesajı olan üye bulunamadı._"
-        );
-      }
-
-      let final_msg = `📊 _${usersWithMessages.length} üyenin gönderdiği mesajlar_\n_Mesaj sayısına göre sıralı (en yüksekten en düşüğe)_\n\n`;
-
-      for (let userObj of usersWithMessages) {
-        let user = userObj.jid;
-        let userStat = userObj.stat;
-        let count = userStat.totalMessages;
-        let name = userStat.User?.name?.replace(/[\r\n]+/gm, "") || "Bilinmiyor";
-        let lastMsg = timeSince(userStat.lastMessageAt);
-        let types_msg = "\n";
-        if (userStat.textMessages > 0)
-          types_msg += `_Metin: *${userStat.textMessages}*_\n`;
-        if (userStat.imageMessages > 0)
-          types_msg += `_Görsel: *${userStat.imageMessages}*_\n`;
-        if (userStat.videoMessages > 0)
-          types_msg += `_Video: *${userStat.videoMessages}*_\n`;
-        if (userStat.audioMessages > 0)
-          types_msg += `_Ses: *${userStat.audioMessages}*_\n`;
-        if (userStat.stickerMessages > 0)
-          types_msg += `_Çıkartma: *${userStat.stickerMessages}*_\n`;
-        if (userStat.otherMessages > 0)
-          types_msg += `_Diğer: *${userStat.otherMessages}*_\n`;
-        final_msg += `_Katılımcı: *+${
-          user.split("@")[0]
-        }*_\n_İsim: *${name}*_\n_Toplam mesaj: *${count}*_\n_Son mesaj: *${lastMsg}*_${types_msg}\n\n`;
-      }
-
-      return await message.sendReply(final_msg);
     }
+
+    usersWithMessages.sort((a, b) => b.stat.totalMessages - a.stat.totalMessages);
+
+    if (usersWithMessages.length === 0) {
+      return await message.sendReply("❌ _Veritabanında mesaj gönderen üye bulunamadı._");
+    }
+
+    let final_msg = `👥 _${usersWithMessages.length} üye tarafından gönderilen mesajlar_
+🏆 _Mesaj sayısına göre sıralanmış (en yüksekten en düşüğe)_
+
+`;
+    let mentionsList = [];
+
+    for (let i = 0; i < usersWithMessages.length; i++) {
+      let userObj = usersWithMessages[i];
+      let user = userObj.jid;
+      let userStat = userObj.stat;
+      let count = userStat.totalMessages;
+      let name = userStat.User?.name?.replace(/[\r\n]+/gm, "") || "Bilinmiyor";
+      let lastMsg = timeSince(userStat.lastMessageAt);
+      let types_msg = "\n";
+
+      if (userStat.textMessages > 0)
+        types_msg += `💬 Metin: *${userStat.textMessages}*\n`;
+      if (userStat.imageMessages > 0)
+        types_msg += `🖼️ Görsel: *${userStat.imageMessages}*\n`;
+      if (userStat.videoMessages > 0)
+        types_msg += `🎥 Video: *${userStat.videoMessages}*\n`;
+      if (userStat.audioMessages > 0)
+        types_msg += `🎙 Ses: *${userStat.audioMessages}*\n`;
+      if (userStat.stickerMessages > 0)
+        types_msg += `🎨 Çıkartma: *${userStat.stickerMessages}*\n`;
+      if (userStat.otherMessages > 0)
+        types_msg += `📎 Diğer: *${userStat.otherMessages}*\n`;
+
+      mentionsList.push(user);
+      final_msg += `${i + 1}. 👤 Üye: @${user.split("@")[0]}\n`;
+      final_msg += `📝 İsim: *${name}*\n`;
+      final_msg += `📊 Toplam mesaj: *${count}*\n`;
+      final_msg += `🕒 Son mesaj: *${lastMsg}*${types_msg}\n`;
+    }
+
+    return await message.client.sendMessage(message.jid, {
+      text: final_msg,
+      mentions: mentionsList,
+    });
   }
 );
+
 
 Module(
   {
@@ -164,7 +200,7 @@ Module(
       const durationStr = args[0];
       const shouldKick = args[1]?.toLowerCase() === "kick";
 
-      const cutoffDate = parseDuration(durationStr);
+      const cutoffDate = parseDurationInput(durationStr);
       if (!cutoffDate) {
         return await message.sendReply("_❌ Geçersiz süre formatı!_\n" + "_Examples:_ 30d, 2w, 3m, 1y"
         );
@@ -313,6 +349,140 @@ Module(
     }
   }
 );
+
+
+Module(
+  {
+    pattern: "üyetemizle ?(.*)",
+    fromMe: false,
+    desc: "Belirtilen süre boyunca mesaj atmayan üyeleri listeler veya çıkarır.",
+    usage:
+      ".üyetemizle 30 gün | .üyetemizle 2 hafta | .üyetemizle 3 ay | .üyetemizle 1 yıl\n\n" +
+      "Komutun sonuna 'çıkar' ekleyerek üyeleri gruptan atabilirsiniz.",
+    use: "group",
+  },
+  async (message, match) => {
+    try {
+      if (!message.isGroup) {
+        return await message.sendReply("❌ _Bu komut sadece grup sohbetlerinde kullanılabilir!_");
+      }
+      const admin = await isAdmin(message, message.sender);
+      if (!admin) {
+        return await message.sendReply("❌ _Bu komut yalnızca grup yöneticileri tarafından kullanılabilir!_");
+      }
+      if (!match[1]) {
+        return await message.sendReply(
+          "❗  *Lütfen şu şekillerde kullanınız:*\n" +
+            ".üyetemizle 30 gün\n" +
+            ".üyetemizle 2 hafta\n" +
+            ".üyetemizle 3 ay\n" +
+            ".üyetemizle 1 yıl\n" +
+            "🧹 _(Üyeleri çıkarmak için komut sonuna *çıkar* ekleyebilirsiniz.)_"
+        );
+      }
+      const args = match[1].trim().split(/\s+/);
+      const durationStr = args[0];
+      const durationUnit = args[1]?.toLowerCase();
+      const shouldKick = args.includes("çıkar");
+      const durationMs = parseDuration(durationStr, durationUnit);
+      if (!durationMs) {
+        return await message.sendReply(
+          "❌ _Geçersiz süre formatı!_\n" +
+            "Örnekler:\n" +
+            ".üyetemizle 30 gün\n" +
+            ".üyetemizle 2 hafta\n" +
+            ".üyetemizle 3 ay\n" +
+            ".üyetemizle 1 yıl çıkar"
+        );
+      }
+      const cutoffDate = new Date(Date.now() - durationMs);
+      const groupMetadata = await message.client.groupMetadata(message.jid);
+      const participants = groupMetadata.participants.map((p) => p.id);
+      const admins = groupMetadata.participants.filter((p) => p.admin !== null).map((p) => p.id);
+      const userStats = await fetchFromStore(message.jid);
+      let oldestMessageDate = null;
+      if (userStats.length > 0) {
+        const oldest = userStats.reduce((oldest, current) => {
+          const currDate = new Date(current.lastMessageAt || current.createdAt);
+          const oldDate = new Date(oldest.lastMessageAt || oldest.createdAt);
+          return currDate < oldDate ? current : oldest;
+        });
+        oldestMessageDate = new Date(oldest.lastMessageAt || oldest.createdAt);
+      }
+      const dataWarning = oldestMessageDate && cutoffDate < oldestMessageDate;
+      let inactiveMembers = [];
+      for (const user of participants) {
+        if (admins.includes(user)) continue;
+        const userStat = userStats.find((stat) => stat.userJid === user);
+        if (!userStat || !userStat.lastMessageAt) {
+          inactiveMembers.push({ jid: user, lastMessage: "*Hiç mesaj yok*", totalMessages: userStat?.totalMessages || 0 });
+          continue;
+        }
+        const lastMsgDate = new Date(userStat.lastMessageAt);
+        if (lastMsgDate < cutoffDate) {
+          inactiveMembers.push({ jid: user, lastMessage: timeSince(userStat.lastMessageAt, "tr"), totalMessages: userStat.totalMessages });
+        }
+      }
+      if (shouldKick) {
+        const botIsAdmin = await isAdmin(message);
+        if (!botIsAdmin) {
+          return await message.sendReply("⚠️ _Üzgünüm! Üyeleri çıkarabilmem için yönetici olmam gerekiyor._");
+        }
+        if (inactiveMembers.length === 0) {
+          return await message.sendReply("😎 _Belirtilen süre zarfında çıkarılacak inaktif üye bulunamadı._");
+        }
+        const kickMsg =
+          `⚠️ _Dikkat! Bu işlem geri alınamaz._\n` +
+          `🧹 _Toplam ${inactiveMembers.length} üye ${durationStr} ${durationUnit} boyunca sessiz kaldıkları için çıkarılacaklar._\n` +
+          `_5 saniye içinde başlıyoruz. Dua etmeye başlayın..._ 🥲`;
+        await message.client.sendMessage(message.jid, { text: kickMsg, mentions: inactiveMembers.map((m) => m.jid) });
+        await sendBanAudio(message);
+        await new Promise((r) => setTimeout(r, 5000));
+        let kickCount = 0;
+        for (let i = 0; i < Math.min(inactiveMembers.length, 20); i++) {
+          const member = inactiveMembers[i];
+          try {
+            await new Promise((r) => setTimeout(r, 3000));
+            await message.client.groupParticipantsUpdate(message.jid, [member.jid], "remove");
+            kickCount++;
+            if (kickCount % 5 === 0) {
+              await message.send(`_Şu ana kadar ${kickCount}/${inactiveMembers.length} üye gruptan çıkarıldı..._`);
+            }
+          } catch (err) {
+            console.error("Üye çıkarılırken hata:", err);
+            await message.send(`❌ @${member.jid.split("@")[0]} çıkarılırken bir sorun oluştu.`);
+          }
+        }
+        return await message.send(`✅ _Toplam ${kickCount}/${inactiveMembers.length} inaktif üye gruptan çıkarıldı._`);
+      }
+      if (inactiveMembers.length === 0) {
+        return await message.sendReply(`_Belirtilen süre (${durationStr} ${durationUnit}) için inaktif üye bulunamadı._`);
+      }
+      let responseMsg =
+        `ℹ️ *Son _${durationStr} ${durationUnit}_ boyunca mesaj atmayan üyeler;* _(${inactiveMembers.length})_\n` +
+        `_(Kendilerine birer fatiha okuyalım)_ 🥲\n\n`;
+      if (dataWarning) {
+        responseMsg +=
+          `⚠️ _Dikkat! Veritabanı yalnızca ${timeSince(oldestMessageDate, "tr")}'den itibaren kayıt tutuyor. ` +
+          `Bu tarihten önce aktif olanlar da inaktif sayılmış olabilir._\n\n`;
+      }
+      for (let i = 0; i < inactiveMembers.length; i++) {
+        const member = inactiveMembers[i];
+        responseMsg += `${i + 1}. @${member.jid.split("@")[0]}\n`;
+        responseMsg += `   _Son mesaj:_ ${member.lastMessage}\n`;
+        responseMsg += `   _Toplam mesaj:_ ${member.totalMessages}\n\n`;
+      }
+      return await message.client.sendMessage(message.jid, {
+        text: responseMsg,
+        mentions: inactiveMembers.map((m) => m.jid),
+      });
+    } catch (err) {
+      console.error("üyetemizle komutunda hata:", err);
+      return await message.sendReply("⚠️ _Bir hata oluştu. Lütfen tekrar deneyin._");
+    }
+  }
+);
+
 
 Module(
   {

--- a/plugins/removebg.js
+++ b/plugins/removebg.js
@@ -1,0 +1,208 @@
+const { Module } = require("../main");
+const axios = require("axios");
+const FormData = require("form-data");
+const fs = require("fs");
+const Path = require("path");
+
+const RBG_KEYS = ["VwXQes36L5fpTjmMiFpwsy3W", "mkxdVteyNZZhx7fb6y6yqQ6o"];
+
+function getFileNameFromUrl(url, defaultName = "arkaplan") {
+  try {
+    const parsed = new URL(url);
+    let filename = Path.basename(parsed.pathname);
+    if (!Path.extname(filename)) filename += ".jpg";
+    return filename;
+  } catch {
+    return `${defaultName}.jpg`;
+  }
+}
+
+function getDateBasedName(prefix = "Arkaplan") {
+  const date = new Date();
+  const yyyy = String(date.getFullYear());
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const HH = String(date.getHours()).padStart(2, "0");
+  const MM = String(date.getMinutes()).padStart(2, "0");
+  const SS = String(date.getSeconds()).padStart(2, "0");
+  return `${prefix}-${yyyy}${mm}${dd}_${HH}${MM}${SS}`;
+}
+
+Module(
+  {
+    pattern: "apsil ?(.*)",
+    fromMe: false,
+    use: "ai",
+    desc: `Yapay zeka kullanarak görüntünün arka planını kaldırır veya düz renk/resim ile değiştirir.
+👤 *Kullanım Örnekleri:*
+• .apsil                → Arka planı şeffaf (kaldırır)
+• .apsil mavi           → Arkaplan mavi
+• .apsil #ff0000        → Arkaplan kırmızı (hex kodu)
+• .apsil https://resim  → Arkaplan olarak URL'deki fotoğrafı kullan`,
+  },
+  async (message, match) => {
+    if (!message.reply_message?.image && !message.reply_message?.document) {
+      return await message.send(
+        "❗ _Bir fotoğrafa veya belgeye yanıtlayarak yazınız._\n💬 Örnek: `.apsil`\n`.apsil kırmızı`\n`.apsil #00ff00`\n`.apsil https://...`"
+      );
+    }
+
+    const colorMap = {
+      kırmızı: "ff0000",
+      red: "ff0000",
+      mavi: "0000ff",
+      blue: "0000ff",
+      yeşil: "00ff00",
+      green: "00ff00",
+      sarı: "ffff00",
+      yellow: "ffff00",
+      mor: "800080",
+      purple: "800080",
+      pembe: "ff69b4",
+      pink: "ff69b4",
+      turuncu: "ffa500",
+      orange: "ffa500",
+      siyah: "000000",
+      black: "000000",
+      beyaz: "ffffff",
+      white: "ffffff",
+      gri: "808080",
+      gray: "808080",
+      grey: "808080",
+    };
+
+    let userInput = "";
+    if (typeof match === "string") userInput = match.trim().toLowerCase();
+    else if (Array.isArray(match) && match[1]) userInput = match[1].trim().toLowerCase();
+
+    let bgColor = null;
+    let bgImageUrl = null;
+    let processingMsg;
+    let okMsg;
+
+    if (!userInput) {
+      processingMsg = "🧹 _Arka plan kaldırılıyor..._";
+      okMsg = "✨ _Arka plan temizlendi!_";
+    } else if (userInput.startsWith("#")) {
+      bgColor = userInput.replace("#", "");
+      processingMsg = `🎨 _Arka plan ${userInput} olarak ayarlanıyor..._`;
+      okMsg = `✨ _Arka plan ${userInput} yapıldı!_`;
+    } else if (colorMap[userInput]) {
+      bgColor = colorMap[userInput];
+      processingMsg = `🎨 _Arka plan *${userInput}* olarak ayarlanıyor..._`;
+      okMsg = `✨ _Arka plan ${userInput} yapıldı!_`;
+    } else if (userInput.startsWith("http")) {
+      bgImageUrl = userInput;
+      processingMsg = "🖼️ _Belirtilen fotoğraf arka plan olarak uygulanıyor..._";
+      okMsg = "✨ _Arka plan olarak özel bir resim uygulandı!_";
+    } else {
+      return await message.send(
+        "❗ _Sadece renk yazabilir, hex kodu gönderebilir ya da resim URL'i belirtebilirsiniz._"
+      );
+    }
+
+    const processing = await message.send(processingMsg);
+
+    let imagePath;
+    let outputPath;
+
+    try {
+      imagePath = await message.reply_message.download();
+      const imageBuffer = fs.readFileSync(imagePath);
+
+      let response = null;
+      let lastError = null;
+
+      for (let i = 0; i < RBG_KEYS.length; i++) {
+        try {
+          const formData = new FormData();
+          formData.append("image_file", imageBuffer, { filename: "image.jpg" });
+          formData.append("type", "auto");
+          formData.append("size", "auto");
+          if (bgColor) formData.append("bg_color", bgColor);
+          if (bgImageUrl) formData.append("bg_image_url", bgImageUrl);
+
+          response = await axios({
+            method: "post",
+            url: "https://api.remove.bg/v1.0/removebg",
+            data: formData,
+            headers: { ...formData.getHeaders(), "X-Api-Key": RBG_KEYS[i] },
+            responseType: "arraybuffer",
+          });
+
+          console.log(`✅ Remove.bg API başarılı - Anahtar #${i + 1} kullanıldı`);
+          break;
+        } catch (error) {
+          lastError = error;
+          console.log(`❌ Anahtar #${i + 1} başarısız:`, error.response?.status || error.message);
+
+          if (error.response && [402, 403, 429].includes(error.response.status)) {
+            continue;
+          }
+          break;
+        }
+      }
+
+      if (!response) {
+        let errorMessage = "❌ _İşlem başarısız oldu!_";
+
+        if (lastError?.response?.status === 400) {
+          errorMessage =
+            "❌ _Geçersiz parametre veya fotoğraf! Lütfen düz renk, hex kodu veya geçerli bir görsel URL girin._";
+        } else if (lastError?.response?.status === 402) {
+          errorMessage = "❌ _API limiti aşıldı! Lütfen daha sonra tekrar deneyin._";
+        } else if (lastError?.response?.status === 403) {
+          errorMessage = "❌ _API anahtarı geçersiz! Lütfen API key ayarlarını kontrol edin._";
+        } else if (lastError?.response?.status === 413) {
+          errorMessage = "❌ _Dosya çok büyük! Maksimum 22MB olmalı._";
+        } else if (lastError?.response?.status === 415) {
+          errorMessage = "❌ _Desteklenmeyen medya türü! Uygun bir dosya formatı kullanın._";
+        } else if (lastError?.response?.status === 429) {
+          errorMessage = "❌ _İstek limiti aşıldı! Lütfen biraz bekleyin ve tekrar deneyin._";
+        }
+
+        await message.edit(errorMessage, message.jid, processing.key);
+        return;
+      }
+
+      const mimeType = response.headers["content-type"] || "image/png";
+      const extension = (mimeType.split("/")[1] || "png").split(";")[0];
+      outputPath = `rbg_${Date.now()}.${extension}`;
+      fs.writeFileSync(outputPath, response.data);
+
+      let originalFileName = "";
+      try {
+        const docName = message.reply_message.data?.message?.documentMessage?.fileName;
+        if (docName) {
+          const base = Path.parse(docName).name;
+          originalFileName = `${base}.${extension}`;
+        }
+      } catch {}
+
+      if (!originalFileName && bgImageUrl) {
+        originalFileName = getFileNameFromUrl(bgImageUrl, "arkaplan");
+      }
+
+      if (!originalFileName) {
+        originalFileName = `${getDateBasedName("Arkaplan")}.${extension}`;
+      }
+
+      await message.edit(okMsg, message.jid, processing.key);
+      await message.client.sendMessage(
+        message.jid,
+        {
+          document: fs.readFileSync(outputPath),
+          fileName: originalFileName,
+          mimetype: mimeType,
+        },
+        { quoted: message.quoted }
+      );
+    } catch (error) {
+      console.error("APSil komutu hatası:", error);
+      await message.edit("❌ _Dosya gönderilirken bir hata oluştu!_", message.jid, processing.key);
+    } finally {
+      if (imagePath && fs.existsSync(imagePath)) fs.unlinkSync(imagePath);
+      if (outputPath && fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
+    }
+  }
+);

--- a/plugins/sayac.js
+++ b/plugins/sayac.js
@@ -1,0 +1,196 @@
+const { Module } = require('../main');
+const moment = require('moment-timezone');
+
+moment.tz.setDefault('Europe/Istanbul');
+moment.locale('tr');
+
+const yks = 'YKS Sınavlarına ne kadar süre kaldığını belirtir.';
+const msu = 'MSÜ Sınavına ne kadar süre kaldığını belirtir.';
+const kpss = 'KPSS Sınavına ne kadar süre kaldığını belirtir.';
+const okul = 'Okulların kapanmasına ne kadar süre kaldığını belirtir.';
+const oruc = 'Ramazan ayına ne kadar süre kaldığını belirtir.';
+
+function calculateTime(futureTime) {
+  const future = moment(futureTime, 'YYYY-MM-DD HH:mm:ss');
+  const now = moment();
+  const diff = future.diff(now);
+
+  if (diff <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+
+  const duration = moment.duration(diff);
+
+  return {
+    days: Math.floor(duration.asDays()),
+    hours: duration.hours(),
+    minutes: duration.minutes(),
+    seconds: duration.seconds(),
+  };
+}
+
+function findClosestDate(dates) {
+  const now = moment();
+  let closestDate = null;
+  let minDiff = Infinity;
+
+  dates.forEach((dateObj) => {
+    const date = moment(dateObj.date);
+    const diff = date.diff(now);
+
+    if (diff >= 0 && diff < minDiff) {
+      minDiff = diff;
+      closestDate = dateObj;
+    }
+  });
+
+  return closestDate;
+}
+
+Module(
+  {
+    pattern: 'ykssayaç',
+    fromMe: false,
+    desc: yks,
+    use: 'utility',
+  },
+  async (m) => {
+    const sinavsonuc = '2026-07-22 07:30:00';
+    const tercihbaslangic = '2025-07-30 00:00:00';
+    const tercihbitis = '2025-08-08 23:59:59';
+    const now = moment();
+
+    if (now.isAfter(moment(tercihbitis, 'YYYY-MM-DD HH:mm:ss'))) {
+      const time1 = calculateTime('2026-06-20 10:15:00');
+      const time2 = calculateTime('2026-06-21 10:15:00');
+      const time3 = calculateTime('2026-06-21 15:45:00');
+
+      await m.sendReply(
+        `⏳ *TYT* sınavına *${time1.days} gün ${time1.hours} saat ${time1.minutes} dakika ${time1.seconds} saniye* kaldı!\n📅 *20 Haziran 2026 - 10:15*\n\n` +
+          `⏳ *AYT* sınavına *${time2.days} gün ${time2.hours} saat ${time2.minutes} dakika ${time2.seconds} saniye* kaldı!\n📅 *21 Haziran 2026 - 10:15*\n\n` +
+          `⏳ *YDT* sınavına *${time3.days} gün ${time3.hours} saat ${time3.minutes} dakika ${time3.seconds} saniye* kaldı!\n📅 *21 Haziran 2026 - 15:45*`
+      );
+    } else if (now.isBefore(moment(sinavsonuc, 'YYYY-MM-DD HH:mm:ss'))) {
+      const timeToResults = calculateTime(sinavsonuc);
+      await m.sendReply(
+        `👀 YKS sonuçlarının açıklanmasına *${timeToResults.days} gün ${timeToResults.hours} saat ${timeToResults.minutes} dakika ${timeToResults.seconds} saniye* kaldı!\n📅 *22 Temmuz 2025 - 07:30*`
+      );
+    } else if (now.isBefore(moment(tercihbaslangic, 'YYYY-MM-DD HH:mm:ss'))) {
+      const timeToPreferences = calculateTime(tercihbaslangic);
+      await m.sendReply(
+        `🎓 YKS tercihlerinin başlamasına *${timeToPreferences.days} gün ${timeToPreferences.hours} saat ${timeToPreferences.minutes} dakika ${timeToPreferences.seconds} saniye* kaldı!\n📅 *31 Temmuz 2025*`
+      );
+    } else if (now.isBefore(moment(tercihbitis, 'YYYY-MM-DD HH:mm:ss'))) {
+      const timeToEnd = calculateTime(tercihbitis);
+      await m.sendReply(
+        `⏰ YKS tercihlerinin bitmesine *${timeToEnd.days} gün ${timeToEnd.hours} saat ${timeToEnd.minutes} dakika ${timeToEnd.seconds} saniye* kaldı!\n📅 *8 Ağustos 2025 - 23:59*`
+      );
+    } else {
+      const time1 = calculateTime('2026-06-20 10:15:00');
+      await m.sendReply(
+        `🆕 2026 YKS süreci başladı!\n⏳ *TYT* sınavına ${time1.days} gün kaldı.\n📅 *20 Haziran 2026 - 10:15*`
+      );
+    }
+  }
+);
+
+Module(
+  {
+    pattern: 'kpsssayaç',
+    fromMe: false,
+    desc: kpss,
+    use: 'utility',
+  },
+  async (m) => {
+    const lisans = calculateTime('2026-09-06 10:15:00');
+    const onlisans = calculateTime('2026-10-04 10:15:00');
+    const ortaogretim = calculateTime('2026-10-25 10:15:00');
+    const ekpss = calculateTime('2026-04-19 10:15:00');
+    await m.sendReply(
+      `_(TAHMİNİ)_\n⏳ KPSS *(Lisans)* sınavına *${lisans.days} gün ${lisans.hours} saat ${lisans.minutes} dakika ${lisans.seconds} saniye* kaldı!\n📅 *26 Temmuz 2026 - 10:15*\n\n⏳ KPSS *(Önlisans)* sınavına *${onlisans.days} gün ${onlisans.hours} saat ${onlisans.minutes} dakika ${onlisans.seconds} saniye* kaldı!\n📅 *4 Ekim 2026 - 10:15*\n\n⏳ KPSS *(Ortaöğretim)* sınavına *${ortaogretim.days} gün ${ortaogretim.hours} saat ${ortaogretim.minutes} dakika ${ortaogretim.seconds} saniye* kaldı!\n📅 *25 Ekim 2026 - 10:15*\n\n⏳ *E-KPSS* sınavına *${ekpss.days} gün ${ekpss.hours} saat ${ekpss.minutes} dakika ${ekpss.seconds} saniye* kaldı!\n📅 *19 Nisan 2026 - 10:15*`
+    );
+  }
+);
+
+Module(
+  {
+    pattern: 'msüsayaç',
+    fromMe: false,
+    desc: msu,
+    use: 'utility',
+  },
+  async (m) => {
+    const targetDate = moment('2026-03-01 10:15:00');
+    const now = moment();
+
+    if (now.isAfter(targetDate)) {
+      await m.sendReply(
+        `❗ *OPS! MSÜ sınavı bu yıl için tamamlandı.* ✅\n📅 *1 Mart 2026 - 10:15*`
+      );
+    } else {
+      const time = calculateTime(targetDate);
+      await m.sendReply(
+        `⏳ *MSÜ* sınavına *${time.days} gün ${time.hours} saat ${time.minutes} dakika ${time.seconds}* saniye kaldı!\n📅 *1 Mart 2026 - 10:15*`
+      );
+    }
+  }
+);
+
+Module(
+  {
+    pattern: 'okulsayaç',
+    fromMe: false,
+    desc: okul,
+    use: 'utility',
+  },
+  async (m) => {
+    const schoolDates = [
+      { date: '2025-11-10 08:00:00', label: '1. Dönem ara tatili' },
+      { date: '2026-01-19 08:00:00', label: 'Yarıyıl tatili' },
+      { date: '2026-03-16 08:00:00', label: '2. Dönem ara tatili' },
+      { date: '2026-06-26 08:00:00', label: 'Yaz Tatili' },
+    ];
+    let closestDateObj = findClosestDate(schoolDates);
+    if (!closestDateObj) {
+      closestDateObj = {
+        date: '2025-09-08 08:00:00',
+        label: 'Okulların açılışı',
+      };
+    }
+
+    const time = calculateTime(closestDateObj.date);
+    const formattedDate = moment(closestDateObj.date).format('DD MMMM YYYY - dddd');
+
+    await m.sendReply(
+      `🧐 En yakın tarih: *${closestDateObj.label}*\n⏳ ${
+        closestDateObj.label === 'Okulların açılışı'
+          ? 'Okulların açılmasına'
+          : 'Okulların kapanmasına'
+      } *${time.days} gün ${time.hours} saat ${time.minutes} dakika ${time.seconds}* saniye kaldı! 🥳\n📅 *${formattedDate}*`
+    );
+  }
+);
+
+Module(
+  {
+    pattern: 'ramazansayaç',
+    fromMe: false,
+    desc: oruc,
+    use: 'utility',
+  },
+  async (m) => {
+    const ramazanStart = '2026-02-19 02:23:00';
+    const ramazanEnd = '2026-03-19 19:30:00';
+    const now = moment();
+
+    if (now.isBetween(moment(ramazanStart), moment(ramazanEnd))) {
+      const time = calculateTime(ramazanEnd);
+      await m.sendReply(
+        `⏳ Ramazan ayının bitmesine *${time.days} gün ${time.hours} saat ${time.minutes} dakika ${time.seconds} saniye* kaldı! 🥲\n📅 *19 Mart 2026 - Perşembe*`
+      );
+    } else if (now.isBefore(moment(ramazanStart))) {
+      const time = calculateTime(ramazanStart);
+      await m.sendReply(
+        `⏳ Ramazan ayına girmemize *${time.days} gün ${time.hours} saat ${time.minutes} dakika ${time.seconds} saniye* kaldı! 😍\n📅 *19 Şubat 2026 - Perşembe*`
+      );
+    }
+  }
+);

--- a/plugins/schedule.js
+++ b/plugins/schedule.js
@@ -1,7 +1,6 @@
 const { Module } = require("../main");
 const { scheduledMessages } = require("./utils/db/schedulers");
 const moment = require("moment");
-let config = require("../config");
 
 function isValidJID(text) {
   return (
@@ -10,73 +9,130 @@ function isValidJID(text) {
     text.endsWith("@lid")
   );
 }
+
 function parseTime(timeStr) {
   const now = moment();
   const durationMatch =
-    timeStr.match(/^(\d+)([dhms])$/i) ||
-    timeStr.match(/^(\d+)h(\d+)m$/i) ||
-    timeStr.match(/^(\d+)m(\d+)s$/i);
+    timeStr.match(/^(\d+)\s*(g|gün|gun)$/i) ||
+    timeStr.match(/^(\d+)\s*(s|saat)$/i) ||
+    timeStr.match(/^(\d+)\s*(d|dk|dakika)$/i) ||
+    timeStr.match(/^(\d+)\s*(sn|saniye)$/i) ||
+    timeStr.match(/^(\d+)\s*(saat)\s*(\d+)\s*(dk|dakika)$/i) ||
+    timeStr.match(/^(\d+)\s*(s)\s*(\d+)\s*(dk|dakika)$/i) ||
+    timeStr.match(/^(\d+)\s*(dk|dakika)\s*(\d+)\s*(sn|saniye)$/i);
+
   if (durationMatch) {
     let duration = moment.duration();
-    if (timeStr.includes("h") && timeStr.includes("m")) {
-      const [, hours, minutes] = timeStr.match(/^(\d+)h(\d+)m$/i);
-      duration.add(parseInt(hours), "hours").add(parseInt(minutes), "minutes");
-    } else if (timeStr.includes("m") && timeStr.includes("s")) {
-      const [, minutes, seconds] = timeStr.match(/^(\d+)m(\d+)s$/i);
-      duration
-        .add(parseInt(minutes), "minutes")
-        .add(parseInt(seconds), "seconds");
+    if (
+      (timeStr.includes("saat") || timeStr.match(/\d+s\d+/)) &&
+      (timeStr.includes("dk") || timeStr.includes("dakika"))
+    ) {
+      const match = timeStr.match(/^(\d+)\s*(saat|s)\s*(\d+)\s*(dk|dakika)$/i);
+      if (match) {
+        const [, hours, , minutes] = match;
+        duration.add(parseInt(hours), "hours").add(parseInt(minutes), "minutes");
+      }
+    } else if (
+      (timeStr.includes("dk") || timeStr.includes("dakika")) &&
+      (timeStr.includes("sn") || timeStr.includes("saniye"))
+    ) {
+      const match = timeStr.match(/^(\d+)\s*(dk|dakika)\s*(\d+)\s*(sn|saniye)$/i);
+      if (match) {
+        const [, minutes, , seconds] = match;
+        duration
+          .add(parseInt(minutes), "minutes")
+          .add(parseInt(seconds), "seconds");
+      }
     } else {
       const [, value, unit] = durationMatch;
-      const unitMap = { d: "days", h: "hours", m: "minutes", s: "seconds" };
+      const unitMap = {
+        g: "days",
+        gün: "days",
+        gun: "days",
+        s: "hours",
+        saat: "hours",
+        d: "minutes",
+        dk: "minutes",
+        dakika: "minutes",
+        sn: "seconds",
+        saniye: "seconds",
+      };
       duration.add(parseInt(value), unitMap[unit.toLowerCase()]);
     }
     return now.add(duration).subtract(1, "minute").toDate();
   }
-  const timeMatch = timeStr.match(/^(\d{1,2}):(\d{2})(\s*[ap]m)?$/i);
+
+  const timeMatch = timeStr.match(/^(\d{1,2})[:.](\d{2})$/i);
   if (timeMatch) {
-    let [, hours, minutes, period] = timeMatch;
+    let [, hours, minutes] = timeMatch;
     hours = parseInt(hours);
     minutes = parseInt(minutes);
-    if (period) {
-      period = period.trim().toLowerCase();
-      if (period === "pm" && hours !== 12) hours += 12;
-      if (period === "am" && hours === 12) hours = 0;
-    }
     const targetTime = moment().hours(hours).minutes(minutes).seconds(0);
     if (targetTime.isBefore(now)) {
       targetTime.add(1, "day");
     }
     return targetTime.subtract(1, "minute").toDate();
   }
+
   const dateTime = moment(timeStr, [
-    "YYYY-MM-DD HH:mm",
+    "DD.MM.YYYY HH:mm",
     "DD/MM/YYYY HH:mm",
-    "MM/DD/YYYY HH:mm",
+    "DD.MM.YYYY HH.mm",
+    "YYYY-MM-DD HH:mm",
   ]);
   if (dateTime.isValid()) {
     return dateTime.subtract(1, "minute").toDate();
   }
+
   return null;
 }
-async function createMessageObject(replyMessage) {
+
+async function createMessageObject(
+  replyMessage,
+  mentionJid = null,
+  isGroupMessage = false
+) {
   let messageObj = {};
-  if (replyMessage.text) {
+
+  if (isGroupMessage && mentionJid && replyMessage.text) {
+    const mentionText = `⏰ @${mentionJid.split("@")[0]} `;
+    messageObj.text = mentionText + replyMessage.text;
+    messageObj.mentions = [mentionJid];
+  } else if (replyMessage.text) {
     messageObj.text = replyMessage.text;
   }
+
   if (replyMessage.image) {
     const buffer = await replyMessage.download("buffer");
     messageObj.image = buffer.toString("base64");
-    if (replyMessage.caption) messageObj.caption = replyMessage.caption;
+    if (replyMessage.caption) {
+      if (isGroupMessage && mentionJid) {
+        const mentionText = `⏰ @${mentionJid.split("@")[0]} `;
+        messageObj.caption = mentionText + replyMessage.caption;
+        messageObj.mentions = [mentionJid];
+      } else {
+        messageObj.caption = replyMessage.caption;
+      }
+    }
     messageObj._mediaType = "image";
   }
+
   if (replyMessage.video) {
     const buffer = await replyMessage.download("buffer");
     messageObj.video = buffer.toString("base64");
-    if (replyMessage.caption) messageObj.caption = replyMessage.caption;
+    if (replyMessage.caption) {
+      if (isGroupMessage && mentionJid) {
+        const mentionText = `⏰ @${mentionJid.split("@")[0]} `;
+        messageObj.caption = mentionText + replyMessage.caption;
+        messageObj.mentions = [mentionJid];
+      } else {
+        messageObj.caption = replyMessage.caption;
+      }
+    }
     messageObj._mediaType = "video";
     if (replyMessage.gifPlayback) messageObj.gifPlayback = true;
   }
+
   if (replyMessage.audio) {
     const buffer = await replyMessage.download("buffer");
     messageObj.audio = buffer.toString("base64");
@@ -84,6 +140,7 @@ async function createMessageObject(replyMessage) {
     messageObj._mediaType = "audio";
     if (replyMessage.ptt) messageObj.ptt = true;
   }
+
   if (replyMessage.document) {
     const buffer = await replyMessage.download("buffer");
     messageObj.document = buffer.toString("base64");
@@ -91,145 +148,194 @@ async function createMessageObject(replyMessage) {
     messageObj.mimetype = replyMessage.mimetype;
     messageObj._mediaType = "document";
   }
+
   if (replyMessage.sticker) {
     const buffer = await replyMessage.download("buffer");
     messageObj.sticker = buffer.toString("base64");
     messageObj._mediaType = "sticker";
   }
+
   return JSON.stringify(messageObj);
 }
+
 Module(
   {
-    pattern: "schedule ?(.*)",
+    pattern: "planla ?(.*)",
     use: "utility",
-    desc: "İleri bir tarih için mesaj planlar. Mesajı yanıtlayarak kullanın.",
+    desc: "⏰ Mesaj planla - Gruba veya özele zamanlanmış mesaj gönder",
   },
   async (m, match) => {
-    if (match[1] === "d") return;
     if (!m.reply_message) {
-      return await m.sendReply("_💬 Zamanlamak istediğiniz mesajı yanıtlayın_\n\n*📋 Kullanım:*\n• schedule <jid> <zaman>\n• schedule <zaman> <jid>"
+      return await m.sendReply(
+        "⚠️ _Planlamak istediğiniz mesaja yanıt veriniz._\n\n*📋 Kullanımı:*\n• `.planla @üye <zaman>` (gruba etiketle ve gönder)\n• `.planla dm @üye <zaman>` (özeline gönder)\n\n*⏱️ Zaman formatları:*\n• `2 saat 30 dakika` veya `2saat30dk` veya `2s30dk`\n• `1 gün` veya `1g`\n• `30 dakika` veya `30dk` veya `30 dk`\n• `5 saniye` veya `5sn`\n• `14:30` veya `14.30`\n• `25.12.2026 11:00`"
       );
     }
+
     if (!match[1]) {
-      return await m.sendReply("_💬 Lütfen JID ve zaman sağlayın_\n\n*📋 Örnek:*\n• schedule 905554443322@s.whatsapp.net 2h"
+      return await m.sendReply(
+        "⚠️ _Lütfen üye etiketleyip zaman belirtiniz._\n\n*💡 Örnek:*\n• `.planla @üye 2 saat`\n• `.planla dm @üye 30 dakika`"
       );
     }
-    const args = match[1].trim().split(/\s+/);
-    if (args.length < 2) {
-      return await m.sendReply("_⚠️ Lütfen hem JID hem de zamanı belirtin_");
+
+    let input = match[1].trim();
+    let isDM = false;
+
+    if (input.startsWith("dm ")) {
+      isDM = true;
+      input = input.substring(3).trim();
     }
-    let jid, timeStr;
-    if (isValidJID(args[0])) {
-      jid = args[0];
-      timeStr = args.slice(1).join(" ");
-    } else if (isValidJID(args[args.length - 1])) {
-      jid = args[args.length - 1];
-      timeStr = args.slice(0, -1).join(" ");
-    } else {
-      const jidArg = args.find((arg) => isValidJID(arg));
-      if (jidArg) {
-        jid = jidArg;
-        timeStr = args.filter((arg) => arg !== jidArg).join(" ");
-      } else {
-        return await m.sendReply("_❌ Geçersiz JID formatı. JID, @g.us, @s.whatsapp.net veya @lid ile bitmelidir_"
-        );
-      }
+
+    let targetJid = null;
+    let mentionedUser = m.mention?.[0];
+
+    if (!mentionedUser) {
+      return await m.sendReply(
+        "⚠️ _Lütfen bir üyeyi etiketleyin!_\n\n*💡 Örnek:*\n• `.planla @üye 2 saat`\n• `.planla dm @üye 30 dakika`"
+      );
     }
+
+    targetJid = mentionedUser;
+    input = input.replace(/@\d+/g, "").trim();
+
+    const timeStr = input.trim();
+    if (!timeStr) {
+      return await m.sendReply(
+        "⚠️ _Lütfen zaman belirtin!_\n\n*💡 Örnek:*\n• `.planla @üye 2 saat`\n• `.planla dm @üye 30 dakika`"
+      );
+    }
+
     const scheduleTime = parseTime(timeStr);
     if (!scheduleTime) {
-      return await m.sendReply("_⚠️ Geçersiz zaman formatı_\n\n*📋 Desteklenen formatlar:*\n• 2h30m, 1g, 30m, 5s\n• 14:30, 14:45\n• YYYY-AA-GG SS:dd"
+      return await m.sendReply(
+        "❌ _Geçersiz zaman formatı_\n\n*⏱️ Desteklenen formatlar:*\n• `2 saat 30 dakika`, `2saat30dk`, `2s30dk`\n• `1 gün`, `1g`\n• `30 dakika`, `30dk`, `30 dk`\n• `5 saniye`, `5sn`\n• `14:30`, `14.30`\n• `25.12.2024 14:30`"
       );
     }
+
     const originalTime = moment(scheduleTime).add(1, "minute").toDate();
     if (originalTime <= new Date()) {
-      return await m.sendReply("_⏰ Zamanlama zamanı gelecekte olmalıdır_");
+      return await m.sendReply("⚠️ _Planlama zamanı gelecek zaman olmalıdır._");
     }
+
     const minTime = moment().add(2, "minutes").toDate();
     if (originalTime < minTime) {
-      return await m.sendReply("_⚠️ Minimum zamanlama süresi 2 dakikadır. Lütfen şu andan itibaren en az 2 dakika sonraya ayarlayın._"
+      return await m.sendReply(
+        "⚠️ _Minimum planlama süresi 2 dakikadır. Lütfen en az 2 dakika sonrası için planlayın._"
       );
     }
+
+    const finalJid = isDM ? targetJid : m.jid;
+    const isGroupMessage = !isDM;
+
     try {
-      const messageData = await createMessageObject(m.reply_message);
-      await scheduledMessages.add(jid, messageData, scheduleTime);
+      const messageData = await createMessageObject(
+        m.reply_message,
+        isGroupMessage ? targetJid : null,
+        isGroupMessage
+      );
+
+      await scheduledMessages.add(finalJid, messageData, scheduleTime);
+
+      moment.locale("tr");
       const timeFromNow = moment(scheduleTime).add(1, "minute").fromNow();
       const formattedTime = moment(scheduleTime)
         .add(1, "minute")
-        .format("DD/MM/YYYY HH:mm");
+        .format("DD.MM.YYYY HH:mm");
+
+      const targetInfo = isDM ? "📩 özelden" : "💬 gruba (⏰ etiketli)";
+
       await m.sendReply(
-        `✅ *Mesaj başarıyla zamanlandı!*\n\n📅 *Zaman:* ${formattedTime}\n⏰ *Şu andan itibaren:* ${timeFromNow}\n📱 *Hedef:* ${jid}`
+        `✅ *Mesaj başarıyla planlandı!*\n\n📅 *Tarih:* ${formattedTime}\n⏰ *Kalan süre:* ${timeFromNow}\n📱 *Hedef:* ${targetInfo}\n👤 *Üye:* @${targetJid.split("@")[0]}`,
+        { mentions: [targetJid] }
       );
     } catch (error) {
-      console.error("Zamanlama hatası:", error);
-      await m.sendReply("_❌ Mesaj zamanlanamadı. Lütfen tekrar deneyin._");
+      console.error("Mesaj planlama hatası:", error);
+      await m.sendReply("❌ _Mesaj planlanırken hata oluştu. Lütfen tekrar deneyin._");
     }
   }
 );
+
 Module(
   {
-    pattern: "scheduled ?(.*)",
+    pattern: "plandurum ?(.*)",
     use: "utility",
-    desc: "Bekleyen tüm planlanmış mesajları listeler",
+    desc: "📋 Planlanan tüm mesajları listeler",
   },
   async (m, match) => {
     try {
       const pending = await scheduledMessages.getAllPending();
       if (pending.length === 0) {
-        return await m.sendReply("📭 _Bekleyen zamanlanmış mesaj yok_");
+        return await m.sendReply("📭 _Bekleyen planlı mesaj bulunmuyor._");
       }
-      let response = "📋 *Zamanlanmış Mesajlar*\n\n";
+
+      moment.locale("tr");
+      let response = "📋 *Planlanan Mesajlar*\n\n";
+
       pending.sort(
         (a, b) => a.scheduleTime.getTime() - b.scheduleTime.getTime()
       );
+
       pending.forEach((msg, index) => {
         const timeFromNow = moment(msg.scheduleTime).add(1, "minute").fromNow();
         const formattedTime = moment(msg.scheduleTime)
           .add(1, "minute")
-          .format("DD/MM/YYYY HH:mm");
+          .format("DD.MM.YYYY HH:mm");
+
         const preview = JSON.parse(msg.message);
-        let content = preview.text || preview.caption || "Medya mesajı";
+        let content = preview.text || preview.caption || "🎬 Medya mesajı";
         if (content.length > 30) content = content.substring(0, 30) + "...";
-        response += `${index + 1}. *ID:* ${msg.id}\n`;
-        response += `   *Alıcı:* ${msg.jid}\n`;
-        response += `   *Zaman:* ${formattedTime}\n`;
-        response += `   *Kalan:* ${timeFromNow}\n`;
-        response += `   *İçerik:* ${content}\n\n`;
+
+        response += `${index + 1}. *🆔 ID:* ${msg.id}\n`;
+        response += `   *📱 Gönderilecek:* ${msg.jid}\n`;
+        response += `   *📅 Tarih:* ${formattedTime}\n`;
+        response += `   *⏰ Kalan:* ${timeFromNow}\n`;
+        response += `   *💬 İçerik:* ${content}\n\n`;
       });
-      response += '_Zamanlanmış mesajı iptal etmek için "cancel <id>" kullanın_';
+
+      response += '💡 _Planlı mesajı iptal etmek için ".plansil <id>" yazınız._';
       await m.sendReply(response);
     } catch (error) {
-      console.error("Zamanlanmış listeleme hatası:", error);
-      await m.sendReply("_❌ Zamanlanmış mesajlar alınamadı_");
+      console.error("Planlananlar listelenirken hata:", error);
+      await m.sendReply("❌ _Planlanan mesajlar getirilemedi_");
     }
   }
 );
+
 Module(
   {
-    pattern: "cancel ?(.*)",
+    pattern: "plansil ?(.*)",
     use: "utility",
-    desc: "ID'ye göre zamanlanmış bir mesajı iptal eder",
+    desc: "🗑️ Planlanan mesajı ID ile iptal eder",
   },
   async (m, match) => {
     if (!match[1]) {
-      return await m.sendReply("_💬 İptal edilecek mesajın ID'sini belirtin_\n\n*Kullanım:* cancel <id>"
+      return await m.sendReply(
+        "⚠️ _Lütfen iptal edilecek mesajın ID'sini girin._\n\n*💡 Kullanım:* `.plansil <id>`\n\n_Planlanan mesajları görmek için `.plandurum` yazınız._"
       );
     }
+
     const messageId = parseInt(match[1].trim());
     if (isNaN(messageId)) {
-      return await m.sendReply("_⚠️ Lütfen geçerli bir mesaj ID'si girin_");
+      return await m.sendReply("⚠️ _Lütfen geçerli bir mesaj ID'si girin!_");
     }
+
     try {
       const success = await scheduledMessages.delete(messageId);
       if (success) {
         await m.sendReply(
-          `✅ *Zamanlanmış mesaj ${messageId} başarıyla iptal edildi*`
+          `✅ *Planlı mesaj başarıyla silindi!*\n\n🗑️ *Mesaj ID:* ${messageId}`
         );
       } else {
-        await m.sendReply("❌ *Mesaj bulunamadı veya zaten gönderildi*");
+        await m.sendReply("❌ *Mesaj bulunamadı veya zaten gönderilmiş!*");
       }
     } catch (error) {
-      console.error("Zamanlanmış iptal hatası:", error);
-      await m.sendReply("_❌ Zamanlanmış mesaj iptal edilemedi_");
+      console.error("Planlama iptal hatası:", error);
+      await m.sendReply("❌ _Planlı mesaj iptal edilemedi!_");
     }
   }
 );
+
+module.exports = {
+  isValidJID,
+  parseTime,
+  createMessageObject,
+};

--- a/plugins/warn.js
+++ b/plugins/warn.js
@@ -14,51 +14,55 @@ const handler = HANDLERS !== "false" ? HANDLERS.split("")[0] : "";
 const warnLimit = parseInt(WARN || "4");
 const sudoUsers = (SUDO || "").split(",");
 
+function getNumericId(jid = "") {
+  return String(jid).split("@")[0];
+}
+
 Module(
   {
-    pattern: "warn ?(.*)",
+    pattern: "uyar ?(.*)",
     fromMe: false,
-    desc: "Gruptaki bir kullanıcıyı uyarır. Sınıra ulaştığında atılır.",
-    usage: ".warn @user reason\n.warn reply reason",
+    desc: "Grup üyelerini uyarmaya yarar. Limit aşıldığında üye gruptan atılır.",
+    usage: ".uyar @üye sebep\n.uyar sebep",
     use: "group",
   },
   async (message, match) => {
-    if (!match[0].split(" ")[0]?.toLowerCase().endsWith("warn")) return;
+    if (!match[0].split(" ")[0]?.toLowerCase().endsWith("uyar")) return;
     if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu sadece gruplarda kullanılabilen bir komuttur!_");
+      return await message.sendReply("❌ _Bu komut sadece gruplarda kullanılabilir!_");
 
-    let adminAccess = ADMIN_ACCESS
-      ? await isAdmin(message, message.sender)
-      : false;
-    if (!message.fromOwner && !adminAccess) return;
+    const userIsAdmin = await isAdmin(message, message.sender);
+    if (!userIsAdmin)
+      return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
 
     const botIsAdmin = await isAdmin(message);
     if (!botIsAdmin) {
-      return await message.sendReply("_⚠️ Uyarıları yönetmek için yönetici yetkilerine ihtiyacım var!_"
+      return await message.sendReply(
+        "❌ _Uyarabilmem için öncelikle yönetici olmam gerekiyor!_"
       );
     }
 
     const targetUser = message.mention?.[0] || message.reply_message?.jid;
     if (!targetUser) {
-      return await message.sendReply(`_💬 Lütfen bir kullanıcıdan bahsedin veya mesajını yanıtlayın!_\n\n` +
-          `*Kullanım:*\n` +
-          `• \`${handler}warn @user reason\`\n` +
-          `• \`${handler}warn reply reason\`\n` +
-          `• \`${handler}uyarı @user\` - Uyarıları kontrol et\n` +
-          `• \`${handler}rmwarn @user\` - Bir uyarıyı kaldır\n` +
-          `• \`${handler}resetwarn @user\` - Tüm uyarıları kaldır\n` +
-          `• \`${handler}warnlist\` - Tüm uyarılanları listele`
+      return await message.sendReply(
+        `❗ _Lütfen bir üyeyi etiketleyin veya mesajına yanıt verin!_\n\n` +
+          `🔻 *Kullanımı:* \n` +
+          `• \`${handler}uyar @üye sebep\` - Uyarmaya yarar\n` +
+          `• \`${handler}kaçuyarı @üye\` - Uyarı sayısını gösterir\n` +
+          `• \`${handler}uyarısil @üye\` - 1 uyarıyı siler\n` +
+          `• \`${handler}uyarısıfırla @üye\` - Tüm uyarıları sıfırlar\n` +
+          `• \`${handler}uyarılimit\` - Maksimum uyarı limitini belirler`
       );
     }
 
     const isTargetAdmin = await isAdmin(message, targetUser);
     if (isTargetAdmin) {
-      return await message.sendReply("_⚠️ Grup yöneticileri uyarılamaz!_");
+      return await message.sendReply("❗ _OPS! Yöneticiler uyarılamaz._");
     }
 
-    const targetNumericId = targetUser?.split("@")[0];
+    const targetNumericId = getNumericId(targetUser);
     if (sudoUsers.includes(targetNumericId)) {
-      return await message.sendReply("_🔍 Bot sahiplerini/yöneticileri uyaramazsınız!_");
+      return await message.sendReply("❗ _OPS! Bot geliştiricisi uyarılamaz._");
     }
 
     let rawReason = match[1] || "Sebep belirtilmedi";
@@ -68,10 +72,9 @@ Module(
 
     try {
       await setWarn(message.jid, targetUser, reason, message.sender);
-
       const warnData = await getWarn(message.jid, targetUser, warnLimit);
       const currentWarns = warnData.current;
-      const kalan = warnData.kalan;
+      const remaining = warnData.kalan ?? warnData.remaining;
 
       if (warnData.exceeded) {
         try {
@@ -80,418 +83,364 @@ Module(
             [targetUser],
             "remove"
           );
-
           await message.client.sendMessage(message.jid, {
-            text: `⚠ *Kullanıcı Gruptan Çıkarıldı!*\n\n` +
-              `- Kullanıcı: \`@${targetNumericId}\`\n` +
-              `- Sebep: \`${reason}\`\n` +
-              `- Uyarılar: \`${currentWarns}/${warnLimit} (SINIR AŞILDI)\`\n` +
-              `- İşlem: \`Gruptan çıkarıldı\`\n\n` +
-              `_Kullanıcı uyarı sınırını aştığı için atıldı._`,
+            text:
+              `⚠ *UYARI LİMİTİ AŞILDI!*\n\n` +
+              `👤 Üye: *@${targetNumericId}*\n` +
+              `🤔 Sebep: \`${reason}\`\n` +
+              `🔢 Uyarı Sayısı: \`${currentWarns}/${warnLimit} (LİMİT AŞILDI)\`\n` +
+              `👋🏻 İşlem: \`Gruptan çıkarılma\`\n\n` +
+              `🧹 _Maksimum uyarı sayısını aştığı için üye gruptan atıldı._ 😆`,
             mentions: [targetUser],
           });
         } catch (kickError) {
           await message.client.sendMessage(message.jid, {
-            text: `⚠ *Uyarı Sınırı Aşıldı!*\n\n` +
-              `- Kullanıcı: \`@${targetNumericId}\`\n` +
-              `- Uyarılar: \`${currentWarns}/${warnLimit}\`\n` +
-              `- Hata: \`Kullanıcı atılamadı\`\n\n` +
-              `_Lütfen kullanıcıyı elle çıkarın veya yönetici izinlerimi kontrol edin._`,
+            text:
+              `⚠ *UYARI LİMİTİ AŞILDI!*\n\n` +
+              `👤 Üye: *@${targetNumericId}*\n` +
+              `🔢 Uyarı Sayısı: \`${currentWarns}/${warnLimit}\`\n` +
+              `❌ Hata: \`Üye atılamadı!\`\n\n` +
+              `🛠️ _Lütfen üyeyi manuel çıkarın veya bot'un yönetici yetkisini kontrol edin._`,
             mentions: [targetUser],
           });
         }
       } else {
         await message.client.sendMessage(message.jid, {
-          text: `⚠ *Kullanıcı Uyarıldı!*\n\n` +
-            `- Kullanıcı: \`@${targetNumericId}\`\n` +
-            `- Sebep: \`${reason}\`\n` +
-            `- Uyarılar: \`${currentWarns}/${warnLimit}\`\n` +
-            `- Kalan: \`${kalan}\`\n\n` +
+          text:
+            `⚠ *UYARI!*\n\n` +
+            `👤 Üye: @${targetNumericId}\n` +
+            `🤔 Sebep: \`${reason}\`\n` +
+            `🔢 Uyarı Sayısı: \`${currentWarns}/${warnLimit}\`\n` +
+            `⏳ Kalan Hakkı: \`${remaining}\`\n\n` +
             `${
-              kalan === 1
-                ? "_Sonraki uyarı atılmayla sonuçlanacak!_"
-                : `_${kalan} uyarı daha kaldı._`
+              remaining === 1
+                ? "🫡 _Bir uyarı daha alırsa gruptan atılacak!_"
+                : `🫡 _${remaining} uyarı sonra gruptan atılacak._`
             }`,
           mentions: [targetUser],
         });
       }
     } catch (error) {
-      console.error("Uyarı hatası:", error);
-      await message.sendReply("_⚠️ Uyarı eklenemedi! Lütfen tekrar deneyin._");
+      console.error("Uyarı verme hatası:", error);
+      await message.sendReply("❌ _Uyarı verilemedi! Lütfen tekrar deneyin._");
     }
   }
 );
 
 Module(
   {
-    pattern: "uyarı ?(.*)",
+    pattern: "kaçuyarı ?(.*)",
     fromMe: false,
-    desc: "Bir kullanıcının uyarılarını kontrol eder",
-    usage: ".uyarı @user\n.uyarı reply",
+    desc: "Bir üyenin uyarılarını kontrol etmeyi sağlar.",
+    usage: ".kaçuyarı @üye",
     use: "group",
   },
-  async (message, match) => {
+  async (message) => {
     if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu sadece gruplarda kullanılabilen bir komuttur!_");
+      return await message.sendReply("❌ _Bu komut sadece gruplarda kullanılabilir!_");
 
-    let adminAccess = ADMIN_ACCESS
-      ? await isAdmin(message, message.sender)
-      : false;
-    if (!message.fromOwner && !adminAccess) return;
+    const userIsAdmin = await isAdmin(message, message.sender);
+    if (!userIsAdmin)
+      return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
 
-    const targetUser =
-      message.mention?.[0] || message.reply_message?.jid || message.sender;
-    const targetNumericId = targetUser?.split("@")[0];
+    const targetUser = message.mention?.[0] || message.reply_message?.jid || message.sender;
+    const targetNumericId = getNumericId(targetUser);
 
     try {
-      const uyarı = await getWarn(message.jid, targetUser);
-
-      if (!uyarı || uyarı.length === 0) {
+      const warnings = await getWarn(message.jid, targetUser);
+      if (!warnings || warnings.length === 0) {
         return await message.client.sendMessage(message.jid, {
-          text: `✓ *Uyarı Yok*\n\n` +
-            `- Kullanıcı: \`@${targetNumericId}\`\n` +
-            `- Durum: \`Temiz sicil\`\n` +
-            `- Uyarılar: \`0/${warnLimit}\``,
+          text:
+            `✅ *UYARI BULUNAMADI!*\n\n` +
+            `👤 Üye: *@${targetNumericId}*\n` +
+            `ℹ️ Durumu: *SİCİLİ TEMİZ* 😎\n` +
+            `🔢 Uyarı Sayısı: \`0/${warnLimit}\``,
           mentions: [targetUser],
         });
       }
 
-      const currentWarns = uyarı.length;
-      const kalan = warnLimit - currentWarns;
+      const currentWarns = warnings.length;
+      const remaining = warnLimit - currentWarns;
 
-      let uyarıList = `📋 *Uyarı Geçmişi*\n\n`;
-      uyarıList += `- Kullanıcı: \`@${targetNumericId}\`\n`;
-      uyarıList += `- Toplam Uyarılar: \`${currentWarns}/${warnLimit}\`\n`;
-      uyarıList += `- Kalan: \`${kalan > 0 ? kalan : 0}\`\n\n`;
+      let warningsList = `📋 *UYARI GEÇMİŞİ*\n\n`;
+      warningsList += `👤 Üye: *@${targetNumericId}*\n`;
+      warningsList += `🔢 Toplam Uyarı: \`${currentWarns}/${warnLimit}\`\n`;
+      warningsList += `🥲 Kalan Hakkı: \`${remaining > 0 ? remaining : 0}\`\n\n`;
 
-      uyarı.slice(0, 5).forEach((warn, index) => {
+      warnings.slice(0, 5).forEach((warn, index) => {
         const date = new Date(warn.timestamp).toLocaleString();
-        const warnedByNumeric = warn.warnedBy?.split("@")[0];
-        uyarıList += `*${index + 1}.* ${warn.reason}\n`;
-        uyarıList += `   _Uyaran: @${warnedByNumeric}_\n`;
-        uyarıList += `   _Tarih: ${date}_\n\n`;
+        const warnedByNumeric = getNumericId(warn.warnedBy);
+        warningsList += `🤔 Sebep: *${index + 1}.* ${warn.reason}\n`;
+        warningsList += `   👀 _Uyarıyı Veren:_ @${warnedByNumeric}\n`;
+        warningsList += `   📅 _Tarih: *${date}*_\n\n`;
       });
 
-      if (uyarı.length > 5) {
-        uyarıList += `_... ve ${uyarı.length - 5} daha fazla uyarı_\n\n`;
+      if (warnings.length > 5) {
+        warningsList += `_... ve ${warnings.length - 5} uyarı daha görünüyor._ 🧐\n\n`;
       }
 
-      if (kalan <= 0) {
-        uyarıList += `⚠ _Kullanıcı uyarı sınırını aştı!_`;
-      } else if (kalan === 1) {
-        uyarıList += `⚠ _Sonraki uyarı atılmayla sonuçlanacak!_`;
+      if (remaining <= 0) {
+        warningsList += `🫢 _Kullanıcı uyarı limitini aştı!_`;
+      } else if (remaining === 1) {
+        warningsList += `🥲 _Bir sonraki uyarıda atılacak!_`;
       }
 
       await message.client.sendMessage(message.jid, {
-        text: uyarıList,
-        mentions: [targetUser, ...uyarı.slice(0, 5).map((w) => w.warnedBy)],
+        text: warningsList,
+        mentions: [targetUser, ...warnings.slice(0, 5).map((w) => w.warnedBy)],
       });
     } catch (error) {
       console.error("Uyarı kontrol hatası:", error);
-      await message.sendReply("_⚠️ Uyarılar alınamadı!_");
+      await message.sendReply("⚠️ _Uyarılar alınamadı! Tekrar deneyin._");
     }
   }
 );
 
 Module(
   {
-    pattern: "rmwarn ?(.*)",
+    pattern: "uyarısil ?(.*)",
     fromMe: false,
-    desc: "Kullanıcıdan bir uyarıyı siler",
-    usage: ".rmwarn @user\n.rmwarn reply",
+    desc: "Bir kullanıcının bir uyarısını kaldır",
+    usage: ".uyarısil @üye",
     use: "group",
   },
-  async (message, match) => {
+  async (message) => {
     if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu sadece gruplarda kullanılabilen bir komuttur!_");
+      return await message.sendReply("❌ _Bu komut sadece gruplarda kullanılabilir!_");
 
-    let adminAccess = ADMIN_ACCESS
-      ? await isAdmin(message, message.sender)
-      : false;
-    if (!message.fromOwner && !adminAccess) return;
+    const userIsAdmin = await isAdmin(message, message.sender);
+    if (!userIsAdmin)
+      return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
 
     const targetUser = message.mention?.[0] || message.reply_message?.jid;
     if (!targetUser) {
-      return await message.sendReply("_💬 Lütfen bir kullanıcıdan bahsedin veya mesajını yanıtlayın!_"
+      return await message.sendReply(
+        "❗ _Lütfen bir üye etiketleyin veya mesajına yanıtlayın!_"
       );
     }
 
-    const targetNumericId = targetUser?.split("@")[0];
-
+    const targetNumericId = getNumericId(targetUser);
     try {
       const currentCount = await getWarnCount(message.jid, targetUser);
-
       if (currentCount === 0) {
         return await message.client.sendMessage(message.jid, {
-          text: "ℹ *Uyarı Yok*\n\n" +
-            "- Kullanıcı: `@" +
+          text:
+            "🥳 *Hiç uyarısı yok!*\n\n" +
+            "👤 Üye: `@" +
             targetNumericId +
             "`\n" +
-            "- Durum: `Kaldırılacak uyarı yok`",
+            "ℹ️ Durumu: `Silinecek uyarı bulunamadı`",
           mentions: [targetUser],
         });
       }
 
       const removed = await decrementWarn(message.jid, targetUser);
-
       if (removed) {
         const newCount = await getWarnCount(message.jid, targetUser);
         await message.client.sendMessage(message.jid, {
-          text: "✓ *Uyarı Kaldırıldı!*\n\n" +
-            "- Kullanıcı: `@" +
+          text:
+            "✅ *UYARI SİLİNDİ!*\n\n" +
+            "👤 Üye: *@" +
             targetNumericId +
-            "`\n" +
-            "- Kaldırıldı: `1 uyarı`\n" +
-            "- Kalan: `" +
+            "*\n" +
+            "⛔ Silinen: `1 uyarı`\n" +
+            "🔢 Kalan: `" +
             newCount +
             " uyarı`\n" +
-            "- Durum: `" +
-            (newCount === 0 ? "Temiz sicil" : "Hâlâ uyarıları var") +
-            "`",
+            "ℹ️ Durumu: *" +
+            (newCount === 0 ? "SİCİLİ TEMİZ 😎" : "Hâlâ uyarısı mevcut") +
+            "*",
           mentions: [targetUser],
         });
       } else {
-        await message.sendReply("_❌ Uyarı kaldırılamadı!_");
+        await message.sendReply("❌ *Uyarı silinemedi! Tekrar deneyin.*");
       }
     } catch (error) {
       console.error("Uyarı kaldırma hatası:", error);
-      await message.sendReply("_❌ Uyarı kaldırılamadı!_");
+      await message.sendReply("❌ *Uyarı silinemedi! Tekrar deneyin.*");
     }
   }
 );
 
 Module(
   {
-    pattern: "resetwarn ?(.*)",
+    pattern: "uyarısıfırla ?(.*)",
     fromMe: false,
-    desc: "Kullanıcının tüm uyarılarını sıfırlar",
-    usage: ".resetwarn @user\n.resetwarn reply",
+    desc: "Bir üyenin tüm uyarılarını sıfırlar.",
+    usage: ".uyarısıfırla @üye",
     use: "group",
   },
-  async (message, match) => {
+  async (message) => {
     if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu sadece gruplarda kullanılabilen bir komuttur!_");
+      return await message.sendReply("❌ _Bu komut sadece gruplarda kullanılabilir!_");
 
-    let adminAccess = ADMIN_ACCESS
-      ? await isAdmin(message, message.sender)
-      : false;
-    if (!message.fromOwner && !adminAccess) {
-      return await message.sendReply("_🔒 Uyarıları sıfırlamak için yönetici ayrıcalıklarına ihtiyacınız var!_"
+    const userIsAdmin = await isAdmin(message, message.sender);
+    if (!userIsAdmin)
+      return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
+
+    const botIsAdmin = await isAdmin(message);
+    if (!botIsAdmin) {
+      return await message.sendReply(
+        "❌ _Uyarıları sıfırlayabilmem için öncelikle yönetici olmam gerekiyor!_"
       );
     }
 
     const targetUser = message.mention?.[0] || message.reply_message?.jid;
     if (!targetUser) {
-      return await message.sendReply("_💬 Lütfen bir kullanıcıdan bahsedin veya mesajını yanıtlayın!_"
+      return await message.sendReply(
+        "❗ _Lütfen bir üyeyi etiketleyin veya mesajına yanıt verin!_"
       );
     }
 
-    const targetNumericId = targetUser?.split("@")[0];
-
+    const targetNumericId = getNumericId(targetUser);
     try {
       const currentCount = await getWarnCount(message.jid, targetUser);
-
       if (currentCount === 0) {
         return await message.client.sendMessage(message.jid, {
-          text: "ℹ *Uyarı Yok*\n\n" +
-            "- Kullanıcı: `@" +
+          text:
+            "🤯 *UYARI BULUNAMADI!*\n\n" +
+            "👤 Üye: *@" +
             targetNumericId +
-            "`\n" +
-            "- Durum: `Sıfırlanacak uyarı yok`",
+            "*\n" +
+            "ℹ️ Durumu: `Sıfırlanacak uyarı yok`",
           mentions: [targetUser],
         });
       }
 
       const removed = await resetWarn(message.jid, targetUser);
-
       if (removed) {
         await message.client.sendMessage(message.jid, {
-          text: "✓ *Uyarılar Sıfırlandı!*\n\n" +
-            "- Kullanıcı: `@" +
+          text:
+            "✅ *Uyarılar Sıfırlandı!*\n\n" +
+            "👤 Üye: *@" +
             targetNumericId +
-            "`\n" +
-            "- Kaldırıldı: `" +
+            "*\n" +
+            "🔢 Sıfırlanan: `" +
             currentCount +
             " uyarı`\n" +
-            "- Durum: `Temiz sicil`",
+            "ℹ️ Durumu: *SİCİLİ TEMİZ* 😎",
           mentions: [targetUser],
         });
       } else {
-        await message.sendReply("_⚠️ Uyarılar sıfırlanamadı!_");
+        await message.sendReply("❌ *Uyarılar sıfırlanamadı! Tekrar deneyin.*");
       }
     } catch (error) {
       console.error("Uyarı sıfırlama hatası:", error);
-      await message.sendReply("_⚠️ Uyarılar sıfırlanamadı!_");
+      await message.sendReply("❌ *Uyarılar sıfırlanamadı! Tekrar deneyin.*");
     }
   }
 );
 
 Module(
   {
-    pattern: "warnlist",
+    pattern: "uyarıliste",
     fromMe: false,
-    desc: "Gruptaki tüm uyarılan kullanıcıları listeler",
-    usage: ".warnlist",
+    desc: "Grupta uyarı alan tüm üyeleri listeler",
+    usage: ".uyarıliste",
     use: "group",
   },
   async (message) => {
     if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu sadece gruplarda kullanılabilen bir komuttur!_");
+      return await message.sendReply("🚫 _Bu komut sadece gruplarda kullanılabilir!_");
 
     let adminAccess = ADMIN_ACCESS
       ? await isAdmin(message, message.sender)
       : false;
     if (!message.fromOwner && !adminAccess) {
-      return await message.sendReply("_🔒 Uyarı listesini görüntülemek için yönetici yetkilerine ihtiyacınız var!_"
+      return await message.sendReply(
+        "⛔ _Üzgünüm! Öncelikle yönetici olmalısınız.__"
       );
     }
 
     try {
       const allWarnings = await getAllWarns(message.jid);
-
       if (Object.keys(allWarnings).length === 0) {
-        return await message.sendReply(`✓ *Temiz Grup!*\n\n` +
-            `- Bu grupta hiçbir kullanıcının uyarısı yok.\n` +
-            `_Herkes kurallara uyuyor!_`
+        return await message.sendReply(
+          `✅ *GRUP TEMİZ!*\n\n` +
+            `🎉 Bu grupta uyarı alan üye göremedim.\n` +
+            `💯 _Herkes kurallara uyuyor, böyle devam!_ 😎`
         );
       }
-
-      let warnList = `📋 *Grup Uyarı Listesi*\n\n`;
-      warnList += `- Uyarı Sınırı: \`${warnLimit}\`\n\n`;
 
       const sortedUsers = Object.entries(allWarnings).sort(
         ([, a], [, b]) => b.length - a.length
       );
 
-      let mentions = [];
+      let warnList = `📋 *Grup Uyarı Listesi*\n\n`;
+      warnList += `📊 _Toplam uyarılan üye sayısı: *${sortedUsers.length}*_\n\n`;
+      warnList += `⚠️ Uyarı limiti: \`${warnLimit}\`\n\n`;
 
+      let mentions = [];
       sortedUsers.forEach(([userJid, userWarnings], index) => {
         const userNumericId = userJid?.split("@")[0];
         const warnCount = userWarnings.length;
-        const kalan = warnLimit - warnCount;
+        const remaining = warnLimit - warnCount;
         const status =
-          kalan <= 0
-            ? "⚠ SINIR AŞILDI"
-            : kalan === 1
-            ? "⚠ SON UYARI"
-            : `✓ ${kalan} kalan`;
+          remaining <= 0
+            ? "🚫 LİMİT AŞILDI!"
+            : remaining === 1
+            ? "⚠️ SON UYARI"
+            : `🔢 ${remaining} hak kaldı`;
 
-        warnList += `*${index + 1}.* @${userNumericId}\n`;
-        warnList += `   _Uyarılar: \`${warnCount}/${warnLimit}\`_\n`;
-        warnList += `   _Durum: \`${status}\`_\n`;
+        warnList += `*${index + 1}.* 👤 @${userNumericId}\n`;
+        warnList += `   🧾 _Uyarılar: \`${warnCount}/${warnLimit}\`_\n`;
+        warnList += `   📌 _Durum: ${status}_\n`;
 
         if (userWarnings.length > 0) {
           const latestWarning = userWarnings[0];
-          warnList += `   _Son: \`${latestWarning.reason.substring(0, 30)}${
+          warnList += `   🕒 _Son Uyarı Sebebi: ${latestWarning.reason.substring(0, 30)}${
             latestWarning.reason.length > 30 ? "..." : ""
-          }\`_\n`;
+          }_\n`;
         }
         warnList += "\n";
-
         mentions.push(userJid);
       });
 
-      warnList += `_Toplam uyarılan kullanıcı: ${sortedUsers.length}_\n`;
-      warnList += `_Detaylı geçmiş için ${handler}uyarı @user kullanın_`;
-
+      warnList += `ℹ️ _Detaylı uyarı geçmişi için: ${handler}kaçuyarı @üye_`;
       await message.client.sendMessage(message.jid, {
         text: warnList,
         mentions,
       });
     } catch (error) {
-      console.error("Uyarı listeleme hatası:", error);
-      await message.sendReply("_❌ Uyarı listesi alınamadı!_");
+      console.error("Uyarı listesi hatası:", error);
+      await message.sendReply("❌ _Uyarı listesi alınırken bir hata oluştu!_");
     }
   }
 );
 
 Module(
   {
-    pattern: "setwarnlimit ?(.*)",
-    fromMe: true,
-    desc: "Grup için uyarı sınırını ayarlar",
-    usage: ".setwarnlimit 5",
+    pattern: "uyarılimit ?(.*)",
+    fromMe: false,
+    desc: "Grup için uyarı limitini ayarlar",
+    usage: ".uyarılimit 5",
     use: "group",
   },
   async (message, match) => {
+    const userIsAdmin = await isAdmin(message, message.sender);
+    if (!userIsAdmin)
+      return await message.sendReply("❌ _Üzgünüm! Öncelikle yönetici olmalısınız._");
+
     const newLimit = parseInt(match[1]);
-
     if (!newLimit || newLimit < 1 || newLimit > 20) {
-      return await message.sendReply(`⚠ *Geçersiz Uyarı Sınırı*\n\n` +
-          `- Lütfen 1 ile 20 arasında bir sayı girin.\n` +
-          `- Mevcut sınır: \`${warnLimit}\`\n\n` +
-          `*Kullanım:* \`${handler}setwarnlimit 5\``
+      return await message.sendReply(
+        `⚠ *Geçersiz Uyarı Limiti!*\n\n` +
+          `- Lütfen 1 ile 20 arasında bir miktar girin.\n` +
+          `- Mevcut limit: \`${warnLimit}\`\n\n` +
+          `💬 *Kullanım:* \`${handler}uyarılimit 5\``
       );
     }
 
     try {
-      await message.sendReply(`✓ *Uyarı Sınırı Güncellendi!*\n\n` +
-          `- Yeni sınır: \`${newLimit} uyarı\`\n` +
-          `- Önceki sınır: \`${warnLimit}\`\n\n` +
-          `_Kullanıcılar artık ${newLimit} uyarı sonrasında atılacak._`
+      await message.sendReply(
+        `✅ *Uyarı Limiti Güncellendi!*\n\n` +
+          `- Yeni limit: \`${newLimit}\`\n` +
+          `- Önceki limit: \`${warnLimit}\`\n\n` +
+          `ℹ _Üyeler artık ${newLimit} uyarıdan sonra gruptan atılacak._`
       );
     } catch (error) {
-      console.error("Uyarı limiti ayarlama hatası:", error);
-      await message.sendReply("_❌ Uyarı sınırı güncellenemedi!_");
-    }
-  }
-);
-
-Module(
-  {
-    pattern: "warnstats",
-    fromMe: false,
-    desc: "Grup için uyarı istatistiklerini gösterir",
-    usage: ".warnstats",
-    use: "group",
-  },
-  async (message) => {
-    if (!message.isGroup)
-      return await message.sendReply("_ℹ️ Bu sadece gruplarda kullanılabilen bir komuttur!_");
-
-    let adminAccess = ADMIN_ACCESS
-      ? await isAdmin(message, message.sender)
-      : false;
-    if (!message.fromOwner && !adminAccess) {
-      return await message.sendReply("_🔒 Uyarı istatistiklerini görüntülemek için yönetici ayrıcalıklarına ihtiyacınız var!_"
-      );
-    }
-
-    try {
-      const allWarnings = await getAllWarns(message.jid);
-
-      const totalUsers = Object.keys(allWarnings).length;
-      const totalWarnings = Object.values(allWarnings).reduce(
-        (sum, uyarı) => sum + uyarı.length,
-        0
-      );
-
-      let atLimit = 0;
-      let nearLimit = 0;
-      let safe = 0;
-
-      Object.values(allWarnings).forEach((userWarnings) => {
-        const count = userWarnings.length;
-        if (count >= warnLimit) atLimit++;
-        else if (count >= warnLimit - 1) nearLimit++;
-        else safe++;
-      });
-
-      const stats =
-        `📊 *Grup Uyarı İstatistikleri*\n\n` +
-        `- Uyarı Sınırı: \`${warnLimit}\`\n` +
-        `- Toplam Uyarılan Kullanıcı: \`${totalUsers}\`\n` +
-        `- Verilen Toplam Uyarı: \`${totalWarnings}\`\n\n` +
-        `*Kullanıcı Durumu:*\n` +
-        `- ⚠ Sınırda: \`${atLimit}\`\n` +
-        `- ⚠ Sınıra Yakın: \`${nearLimit}\`\n` +
-        `- ✓ Güvende: \`${safe}\`\n\n` +
-        `_Detaylı liste için ${handler}warnlist kullanın_`;
-
-      await message.sendReply(stats);
-    } catch (error) {
-      console.error("Uyarı istatistik hatası:", error);
-      await message.sendReply("_❌ Uyarı istatistikleri alınamadı!_");
+      console.error("Uyarı limiti ayarlanırken hata oluştu:", error);
+      await message.sendReply("❌ _Uyarı limiti güncellenemedi! Tekrar deneyin._");
     }
   }
 );


### PR DESCRIPTION
### Motivation
- Provide several new user-facing utilities (hava/weather, sondepremler, editör, apsil/removebg, sayac) to improve bot usefulness for Turkish users.
- Enhance group management with a more ergonomic kick flow, ban audio, altın (gold) pricing, anti-link auto-delete and localized messages.
- Add richer TTS support (`.ses`) and media editor tools and make scheduling/time parsing work with Turkish time/unit formats.
- Improve warn system UX by renaming commands to Turkish, clarifying messages and hardening admin checks.

### Description
- Added new plugins: `plugins/earthquake.js` (Kandilli live feed and list commands), `plugins/editor.js` (image effect commands), `plugins/removebg.js` (remove.bg integration), `plugins/sayac.js` (exam/event countdowns), and `plugins/fun-tests.js` (group fun-rate commands). 
- Implemented a weather command in `plugins/commands.js` with Turkish city handling, time-based emojis and OpenWeather API calls, plus helper normalization functions.
- Added a TTS-based `.ses` command in `plugins/converters.js` using `aiTTS` fallback to Google TTS and profanity filtering; also imported `badWords` for filtering.
- Refactored group-related features in `plugins/group.js`: added `sendBanAudio`, an `at` kick command with safety checks and audio, `altın` price fetch/parsing, fixed announcement blacklist key (`DUYURU_KARA_LISTE`), improved sabitle flow to wait for Baileys components, and restored/cleaned `etiket`/`ytetiket` commands.
- Extended message stats and management: `plugins/message-stats.js` adds improved time formatting, inactive parsing, `üyetemizle` command for Turkish duration inputs and a `sendBanAudio` helper; `plugins/manage.js` enhanced antilink auto-delete behavior to remove invite links and notify owner group.
- Overhauled scheduler in `plugins/schedule.js`: Turkish-friendly time parsing (`planla`, `plandurum`, `plansil`), `createMessageObject` supports mentions for group-targeted scheduled messages, and exported helpers for reuse.
- Reworked warning system in `plugins/warn.js`: commands renamed/localized (e.g. `uyar`, `kaçuyarı`, `uyarısil`, `uyarısıfırla`, `uyarıliste`, `uyarılimit`), admin validation tightened, messaging reworded, helper `getNumericId` introduced, and behavior on limit exceeded clarified.
- Miscellaneous fixes and small changes across files: improved media handlers, added caching/IO for audio assets, minor parsing/utils enhancements and many Turkish localized user strings.

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b369ee473c83219db3cc427607f07a)