### PR TITLE
Fix animeçiz crash due to invalid quoted payload

### DIFF
--- a/plugins/chatbot.js
+++ b/plugins/chatbot.js
@@ -1005,7 +1005,7 @@ Module({
       await message.edit("✅ _Anime stili uygulandı!_", message.jid, sent.key);
       await message.client.sendMessage(message.jid, {
         image: animeBuffer
-      }, { quoted: message.reply_message });
+      }, { quoted: message.reply_message?.data || message.data });
     } catch (err) {
       console.error("ANİME ÇİZME HATASI:", err.response?.data || err.message);
       if (sent) {


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash when the `animeçiz` command attempts to quote a wrapped message object that lacks the Baileys raw message fields (causing errors like `Cannot read properties of undefined (reading 'fromMe')`).

### Description
- Update `plugins/chatbot.js` to send the converted image with a valid quoted payload by replacing `quoted: message.reply_message` with `quoted: message.reply_message?.data || message.data`.

### Testing
- Ran a syntax check with `node -c plugins/chatbot.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56a7a1a648321801fb232b1bac555)