### PR TITLE
Robustify `.animeçiz` handler: safer upload checks, better error logging, Nexray fallback, and quoting fix

### DIFF
--- a/plugins/chatbot.js
+++ b/plugins/chatbot.js
@@ -976,26 +976,33 @@ Module({
       // 1. Birincil: ZellAPI
       try {
         const uploadResult = await uploadToImgbb(tempFile);
-        const imageUrl = uploadResult.url;
-        const animeResponse = await axios.get(
-          `https://zellapi.autos/ai/applyfilter?imageUrl=${encodeURIComponent(imageUrl)}`,
-          { timeout: 30000 }
-        );
-        if (animeResponse.data?.result) {
-          animeBuffer = await getBuffer(animeResponse.data.result);
-        }
-      } catch (_) {}
+        const imageUrl = uploadResult?.url;
 
-      // 2. Yedek: Nexray gptImage (anime prompt ile dönüştürme)
+        if (imageUrl && imageUrl.startsWith("http")) {
+          const animeResponse = await axios.get(
+            `https://zellapi.autos/ai/applyfilter?imageUrl=${encodeURIComponent(imageUrl)}`,
+            { timeout: 30000 }
+          );
+
+          if (animeResponse.data?.result) {
+            animeBuffer = await getBuffer(animeResponse.data.result);
+          }
+        }
+      } catch (err) {
+        console.error("ZellAPI anime dönüştürme hatası:", err.response?.data || err.message);
+      }
+
+      // 2. Yedek API: Nexray gptImage
       if (!animeBuffer) {
         try {
-          const nexray = require("./utils/nexray");
           animeBuffer = await nexray.gptImage(
             buffer,
             "Transform this photo into high quality anime/manga art style. Keep the same composition and person but make it look like a Japanese anime character.",
             "image/jpeg"
           );
-        } catch (_) {}
+        } catch (err) {
+          console.error("Nexray anime dönüştürme hatası:", err.response?.data || err.message);
+        }
       }
 
       if (!animeBuffer) {
@@ -1005,7 +1012,7 @@ Module({
       await message.edit("✅ _Anime stili uygulandı!_", message.jid, sent.key);
       await message.client.sendMessage(message.jid, {
         image: animeBuffer
-      }, { quoted: message.reply_message });
+      }, { quoted: message.data });
     } catch (err) {
       console.error("ANİME ÇİZME HATASI:", err.response?.data || err.message);
       if (sent) {


### PR DESCRIPTION
### Motivation

- Improve reliability of the anime-style conversion flow by handling failed uploads and API errors gracefully. 
- Provide a working backup path when the primary API fails to avoid user-visible crashes. 
- Fix incorrect quoted message when sending the resulting image.

### Description

- Added checks for `uploadResult?.url` and `imageUrl.startsWith("http")` before calling the primary ZellAPI endpoint to avoid invalid requests. 
- Wrapped ZellAPI and Nexray calls with detailed `console.error` logging to expose `err.response?.data` or `err.message` for easier debugging. 
- Replaced the inline require of Nexray (removed `const nexray = require("./utils/nexray")`) and preserved use of the Nexray `gptImage` fallback to produce an anime image if ZellAPI fails. 
- Fixed message quoting when sending the converted image by using `quoted: message.data` instead of the previous `quoted: message.reply_message`.

### Testing

- Ran `npm run lint` to validate code style and static checks, and it completed successfully. 
- Executed the repository unit tests via `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56a7a1a648321801fb232b1bac555)