### PR TITLE
Add event-loop runtime watchdog and command queuing with timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+const { monitorEventLoopDelay } = require("perf_hooks");
 if (fs.existsSync("./config.env")) {
   require("dotenv").config({ path: "./config.env" });
 }
@@ -45,6 +46,67 @@ const MAX_MESSAGES_PER_JID = 30;
 const MAX_STORE_JIDS = 200;
 
 let _memoryMonitorTimer = null;
+let _runtimeWatchdogTimer = null;
+
+const EVENT_LOOP_WARN_MS = parseInt(process.env.EVENT_LOOP_WARN_MS || "700", 10);
+const EVENT_LOOP_RESTART_MS = parseInt(process.env.EVENT_LOOP_RESTART_MS || "2500", 10);
+const WATCHDOG_INTERVAL_MS = parseInt(process.env.WATCHDOG_INTERVAL_MS || "60000", 10);
+const ALL_BOTS_DOWN_RESTART_MS = parseInt(process.env.ALL_BOTS_DOWN_RESTART_MS || String(8 * 60 * 1000), 10);
+
+let _allBotsDownSince = null;
+
+function getBotSocketState(bot) {
+  const wsReadyState = bot?.sock?.ws?.readyState;
+  // ws.readyState: 1 => OPEN
+  if (wsReadyState === 1) return "open";
+  if (wsReadyState === 0) return "connecting";
+  if (wsReadyState === 2) return "closing";
+  if (wsReadyState === 3) return "closed";
+  return "unknown";
+}
+
+function startRuntimeWatchdog(botManager) {
+  const histogram = monitorEventLoopDelay({ resolution: 20 });
+  histogram.enable();
+
+  _runtimeWatchdogTimer = setInterval(() => {
+    const p99LagMs = Math.round(histogram.percentile(99) / 1e6);
+    histogram.reset();
+
+    if (p99LagMs > EVENT_LOOP_WARN_MS) {
+      logger.warn({ p99LagMs, threshold: EVENT_LOOP_WARN_MS }, "Event loop gecikmesi yüksek");
+    }
+
+    if (p99LagMs > EVENT_LOOP_RESTART_MS) {
+      logger.fatal({ p99LagMs, threshold: EVENT_LOOP_RESTART_MS }, "Event loop kilitlenmesi tespit edildi, process yeniden başlatılıyor");
+      process.exit(1);
+    }
+
+    const states = [];
+    let openCount = 0;
+    for (const [sessionId, bot] of botManager.bots.entries()) {
+      const state = getBotSocketState(bot);
+      if (state === "open") openCount += 1;
+      states.push({ session: sessionId, state });
+    }
+
+    if (states.length > 0 && openCount === 0) {
+      if (!_allBotsDownSince) {
+        _allBotsDownSince = Date.now();
+      }
+      const downForMs = Date.now() - _allBotsDownSince;
+      logger.warn({ downForMs, sessions: states }, "Tüm WhatsApp oturumları bağlı değil");
+      if (downForMs > ALL_BOTS_DOWN_RESTART_MS) {
+        logger.fatal({ downForMs, sessions: states }, "Oturumlar uzun süredir kapalı, process yeniden başlatılıyor");
+        process.exit(1);
+      }
+    } else {
+      _allBotsDownSince = null;
+    }
+  }, WATCHDOG_INTERVAL_MS);
+
+  if (_runtimeWatchdogTimer.unref) _runtimeWatchdogTimer.unref();
+}
 
 function trimBaileysStore(botManager) {
   if (!botManager || !botManager.bots) return 0;
@@ -172,6 +234,7 @@ async function main() {
     if (forceExit.unref) forceExit.unref();
 
     if (_memoryMonitorTimer) clearInterval(_memoryMonitorTimer);
+    if (_runtimeWatchdogTimer) clearInterval(_runtimeWatchdogTimer);
     stopTempCleanup();
     cleanupKickBot();
     try {
@@ -236,6 +299,7 @@ async function main() {
   if (process.env.USE_SERVER !== "false") startServer();
 
   startMemoryMonitor(botManager);
+  startRuntimeWatchdog(botManager);
   startTempCleanup();
 }
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,71 @@ const Commands = [];
 let commandPrefix;
 let handlerPrefix;
 
+const COMMAND_MAX_CONCURRENCY = parseInt(
+  process.env.COMMAND_MAX_CONCURRENCY || "8",
+  10
+);
+const COMMAND_QUEUE_LIMIT = parseInt(
+  process.env.COMMAND_QUEUE_LIMIT || "500",
+  10
+);
+const COMMAND_TIMEOUT_MS = parseInt(
+  process.env.COMMAND_TIMEOUT_MS || "45000",
+  10
+);
+
+let commandActiveCount = 0;
+const commandQueue = [];
+
+function runCommandQueue() {
+  while (
+    commandActiveCount < COMMAND_MAX_CONCURRENCY &&
+    commandQueue.length > 0
+  ) {
+    const queued = commandQueue.shift();
+    commandActiveCount++;
+
+    Promise.resolve()
+      .then(() => queued.task())
+      .catch((e) => {
+        console.error("Komut hatası:", e?.message || e);
+      })
+      .finally(() => {
+        commandActiveCount = Math.max(0, commandActiveCount - 1);
+        setImmediate(runCommandQueue);
+      });
+  }
+}
+
+function enqueueCommand(task) {
+  if (commandQueue.length >= COMMAND_QUEUE_LIMIT) {
+    // Kuyruk dolarsa en eskiyi atarak anlık mesajlara öncelik ver.
+    commandQueue.shift();
+    console.warn(
+      `[Queue] Komut kuyruğu doldu (${COMMAND_QUEUE_LIMIT}), en eski görev düşürüldü.`
+    );
+  }
+  commandQueue.push({ task });
+  setImmediate(runCommandQueue);
+}
+
+async function runWithTimeout(func, args) {
+  let timeoutId;
+  try {
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error(`Komut zaman aşımı (${COMMAND_TIMEOUT_MS}ms)`)),
+        COMMAND_TIMEOUT_MS
+      );
+      if (timeoutId.unref) timeoutId.unref();
+    });
+
+    await Promise.race([Promise.resolve(func(...args)), timeoutPromise]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 function escapeRegex(str) {
   return String(str).replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
@@ -53,9 +118,7 @@ function Module(info, func) {
 
   const wrappedFunc = config.PARALLEL_COMMANDS
     ? async (...args) => {
-        Promise.resolve(func(...args)).catch((e) =>
-          console.error("Komut hatası:", e?.message || e)
-        );
+        enqueueCommand(() => runWithTimeout(func, args));
       }
     : func;
 


### PR DESCRIPTION
### Motivation

- Improve process stability by detecting event-loop stalls and automatically restarting when severe lag or prolonged all-bot disconnection occurs.
- Prevent the bot from being overwhelmed by concurrent commands by adding a configurable command concurrency queue and per-command timeout.

### Description

- Introduces a runtime watchdog in `index.js` that uses `perf_hooks.monitorEventLoopDelay` to measure event-loop latency, logs warnings when latency exceeds `EVENT_LOOP_WARN_MS`, and exits the process when latency exceeds `EVENT_LOOP_RESTART_MS` to allow external process managers to restart the service.
- Adds logic to detect when all bot sockets are not `open`, log the state, and trigger a process restart if all sessions remain down longer than `ALL_BOTS_DOWN_RESTART_MS`; the watchdog interval is configurable via `WATCHDOG_INTERVAL_MS` and timers are unref'd where appropriate.
- Adds cleanup for the runtime watchdog timer during shutdown in `index.js` and minor helpers like `getBotSocketState` and `_allBotsDownSince` tracking.
- Implements a command queue system in `main.js` with configurable `COMMAND_MAX_CONCURRENCY`, `COMMAND_QUEUE_LIMIT`, and `COMMAND_TIMEOUT_MS`, including `enqueueCommand`, `runCommandQueue`, and `runWithTimeout` helpers, and changes `Module` wrapping to enqueue and timeout commands when `config.PARALLEL_COMMANDS` is enabled.

### Testing

- Ran the repository automated test suite via `npm test` and found no regressions (all tests passed).
- Performed an automated startup smoke test that hit the `/health` endpoint after launch and observed the server responding `OK` and the watchdog timer starting successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82e3b813c8321bcf483265a197236)