### PR TITLE
Add auth-health watchdog and degraded_auth mode for persistent decrypt/session failures

### DIFF
--- a/core/auth-health.js
+++ b/core/auth-health.js
@@ -1,0 +1,194 @@
+const { logger } = require("../config");
+
+const SIGNAL_WINDOW_MS = parseInt(process.env.AUTH_SIGNAL_WINDOW_MS || String(5 * 60 * 1000), 10);
+const SIGNAL_THRESHOLD = Math.max(parseInt(process.env.AUTH_SIGNAL_THRESHOLD || "6", 10), 1);
+const LOG_THROTTLE_MS = parseInt(process.env.AUTH_LOG_THROTTLE_MS || "60000", 10);
+const DEGRADED_TTL_MS = parseInt(process.env.AUTH_DEGRADED_TTL_MS || String(30 * 60 * 1000), 10);
+
+const SIGNAL_ERROR_REGEX = /(no\s+session\s+found\s+to\s+decrypt\s+message|failed\s+to\s+decrypt|prekey|invalid\s+pre\s*key|invalid\s+session|session\s+logged\s+out|signal)/i;
+
+const sessions = new Map();
+const logThrottle = new Map();
+
+function getSessionState(sessionId) {
+  if (!sessions.has(sessionId)) {
+    sessions.set(sessionId, {
+      signalErrorTimestamps: [],
+      degradedAuth: false,
+      degradedUntil: 0,
+      operatorAlerted: false,
+      lastSignalText: null,
+    });
+  }
+  const state = sessions.get(sessionId);
+  if (state.degradedAuth && state.degradedUntil && Date.now() > state.degradedUntil) {
+    state.degradedAuth = false;
+    state.degradedUntil = 0;
+    state.operatorAlerted = false;
+  }
+  return state;
+}
+
+function withLogThrottle(key, level, payload, message) {
+  const now = Date.now();
+  const last = logThrottle.get(key) || 0;
+  if (now - last < LOG_THROTTLE_MS) return false;
+  logThrottle.set(key, now);
+  logger[level](payload, message);
+  return true;
+}
+
+function pushSignalError(sessionId, text, meta = {}) {
+  const state = getSessionState(sessionId);
+  const now = Date.now();
+  state.signalErrorTimestamps.push(now);
+  state.signalErrorTimestamps = state.signalErrorTimestamps.filter((t) => now - t <= SIGNAL_WINDOW_MS);
+  state.lastSignalText = text;
+
+  withLogThrottle(
+    `signal:${sessionId}:${String(text || "unknown").toLowerCase()}`,
+    "warn",
+    { session: sessionId, countInWindow: state.signalErrorTimestamps.length, windowMs: SIGNAL_WINDOW_MS, err: text, ...meta },
+    "Signal decrypt/auth hatası algılandı"
+  );
+
+  if (!state.degradedAuth && state.signalErrorTimestamps.length >= SIGNAL_THRESHOLD) {
+    state.degradedAuth = true;
+    state.degradedUntil = now + DEGRADED_TTL_MS;
+
+    logger.error(
+      {
+        session: sessionId,
+        countInWindow: state.signalErrorTimestamps.length,
+        threshold: SIGNAL_THRESHOLD,
+        windowMs: SIGNAL_WINDOW_MS,
+        degradedUntil: new Date(state.degradedUntil).toISOString(),
+      },
+      "Oturum degraded_auth moduna alındı; yüksek maliyetli grup operasyonları geçici askıda"
+    );
+
+    if (!state.operatorAlerted) {
+      state.operatorAlerted = true;
+      logger.error(
+        { session: sessionId },
+        "OPERATÖR UYARISI: SESSION yenile + linked devices temizle"
+      );
+    }
+  }
+
+  return {
+    countInWindow: state.signalErrorTimestamps.length,
+    degradedAuth: state.degradedAuth,
+    degradedUntil: state.degradedUntil,
+  };
+}
+
+function isSignalAuthError(text) {
+  return SIGNAL_ERROR_REGEX.test(String(text || ""));
+}
+
+function noteError(sessionId, errorOrText, meta = {}) {
+  const text = typeof errorOrText === "string"
+    ? errorOrText
+    : [
+      errorOrText?.message,
+      errorOrText?.data,
+      errorOrText?.reason,
+      errorOrText?.stack,
+      errorOrText?.output?.statusCode,
+      errorOrText?.statusCode,
+    ].filter(Boolean).join(" ");
+
+  if (!isSignalAuthError(text)) return null;
+  return pushSignalError(sessionId, text, meta);
+}
+
+function isSessionDegraded(sessionId) {
+  return getSessionState(sessionId).degradedAuth;
+}
+
+function hasAnyDegradedSession(sessionIds = []) {
+  if (sessionIds.length === 0) {
+    return Array.from(sessions.keys()).some((sid) => isSessionDegraded(sid));
+  }
+  return sessionIds.some((sid) => isSessionDegraded(sid));
+}
+
+function classifyForbiddenError(error, operation, sessionId) {
+  const statusCode = Number(
+    error?.output?.statusCode ||
+    error?.statusCode ||
+    error?.response?.status ||
+    error?.data?.status
+  );
+  if (statusCode !== 403) return null;
+
+  const text = [
+    error?.message,
+    error?.data,
+    error?.response?.data?.message,
+    error?.response?.data?.error,
+  ].filter(Boolean).join(" ").toLowerCase();
+
+  let category = "wa_policy_or_temporary";
+  if (/(not\s+admin|admin\s+required|insufficient\s+permission|forbidden\s+to\s+access)/i.test(text)) {
+    category = "missing_admin_privilege";
+  } else if (/(not\s+in\s+group|item-not-found|group\s+not\s+found|participant\s+not\s+found|404)/i.test(text)) {
+    category = "bot_removed_or_not_in_group";
+  }
+
+  withLogThrottle(
+    `forbidden:${sessionId}:${operation}:${category}`,
+    "warn",
+    { session: sessionId, statusCode, operation, category, err: error?.message || String(error) },
+    "403 forbidden grup operasyonu sınıflandırıldı"
+  );
+
+  return { statusCode, operation, category };
+}
+
+function wrapGroupOpsForSession(bot, sessionId) {
+  const sock = bot?.sock;
+  if (!sock || sock.__authHealthWrapped) return;
+
+  const wrap = (methodName, operationName, highCost = false) => {
+    const original = sock[methodName];
+    if (typeof original !== "function") return;
+
+    sock[methodName] = async function wrappedGroupOperation(...args) {
+      if (highCost && isSessionDegraded(sessionId)) {
+        withLogThrottle(
+          `degraded-op:${sessionId}:${operationName}`,
+          "warn",
+          { session: sessionId, operation: operationName, argsPreview: String(args[0] || "") },
+          "degraded_auth nedeniyle yüksek maliyetli grup işlemi geçici olarak atlandı"
+        );
+        const err = new Error(`Operation blocked in degraded_auth mode: ${operationName}`);
+        err.code = "DEGRADED_AUTH_MODE";
+        throw err;
+      }
+
+      try {
+        return await original.apply(this, args);
+      } catch (error) {
+        noteError(sessionId, error, { operation: operationName });
+        classifyForbiddenError(error, operationName, sessionId);
+        throw error;
+      }
+    };
+  };
+
+  wrap("groupMetadata", "groupMetadata", true);
+  wrap("groupParticipantsUpdate", "groupParticipantsUpdate", true);
+  sock.__authHealthWrapped = true;
+}
+
+module.exports = {
+  noteError,
+  isSignalAuthError,
+  isSessionDegraded,
+  hasAnyDegradedSession,
+  classifyForbiddenError,
+  wrapGroupOpsForSession,
+  withLogThrottle,
+};

--- a/core/manager.js
+++ b/core/manager.js
@@ -3,6 +3,7 @@ const { logger, SESSION } = require('../config');
 const { sequelize } = require("./database");
 const { CustomAuthState } = require("./auth");
 const { flushQueueOnShutdown, stopFlushTimer } = require("./store");
+const { wrapGroupOpsForSession } = require("./auth-health");
 
 class BotManager {
     constructor() {
@@ -18,6 +19,7 @@ class BotManager {
                 const bot = new WhatsAppBot(sessionId);
                 await bot.initialize(); 
                 if (bot.sock) { 
+                    wrapGroupOpsForSession(bot, sessionId);
                     this.bots.set(sessionId, bot);
                     logger.info({ session: sessionId }, `Bot başlatma planlandı. Bağlantı durumu takip edilecek.`);
                 } else {

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const {
   stopTempCleanup,
 } = require("./core/helpers");
 const { applyDatabaseCaching, shutdownCache } = require("./core/db-cache");
+const { noteError, hasAnyDegradedSession, withLogThrottle } = require("./core/auth-health");
 
 const MEMORY_CHECK_INTERVAL = 3 * 60 * 1000; // 3 dakikada bir
 const HEAP_WARN_THRESHOLD_MB = 300;
@@ -68,7 +69,7 @@ let _manualReauthMode = false;
 
 function isLikelyPermanentAuthError(text) {
   if (!text) return false;
-  return /(invalid\s*pre\s*key|prekey\s*id|session\s+logged\s+out|logged\s*out|manual\s*re-?auth|device\s*removed|bad\s*session|session\s*invalid|401\b|unauthori[sz]ed)/i.test(text);
+  return /(invalid\s*pre\s*key|prekey\s*id|session\s+logged\s+out|logged\s*out|manual\s*re-?auth|device\s*removed|bad\s*session|session\s*invalid|401\b|unauthori[sz]ed|no\s+session\s+found\s+to\s+decrypt\s+message|failed\s+to\s+decrypt)/i.test(text);
 }
 
 function getBotAuthProblem(bot) {
@@ -92,6 +93,21 @@ function getBotAuthProblem(bot) {
     if (isLikelyPermanentAuthError(text)) return text;
   }
   return null;
+}
+
+
+function attachProcessAuthErrorMonitor(botManager) {
+  process.on("unhandledRejection", (reason) => {
+    try {
+      const text = reason?.message || String(reason || "");
+      if (!isLikelyPermanentAuthError(text)) return;
+      for (const [sessionId] of botManager.bots.entries()) {
+        noteError(sessionId, reason, { source: "unhandledRejection" });
+      }
+    } catch (_) {
+      // best effort
+    }
+  });
 }
 
 function applyCommandIntakeBackpressure(botManager, reason) {
@@ -224,11 +240,18 @@ function startRuntimeWatchdog(botManager) {
           .map(({ session }) => ({ session, issue: getBotAuthProblem(botManager.bots.get(session)) }))
           .filter((x) => x.issue);
         const allPermanentAuth = authIssues.length === states.length && states.length > 0;
+        const anyDegradedAuth = hasAnyDegradedSession(states.map((x) => x.session));
 
-        if (allPermanentAuth) {
+        if (allPermanentAuth || anyDegradedAuth) {
           if (!_manualReauthMode) {
             _manualReauthMode = true;
-            logger.error({ downForMs, authIssues }, "Kalıcı auth hatası tespit edildi (session invalid/prekey). Restart loop engellendi, manual re-auth gerekli");
+            const modeReason = allPermanentAuth ? "permanent-auth" : "degraded-auth-health";
+            withLogThrottle(
+              `all-bots-down-manual-reauth:${modeReason}`,
+              "error",
+              { downForMs, authIssues, sessions: states, modeReason },
+              "All-bots-down: restart yerine manual re-auth uyarısı tercih edildi"
+            );
           }
         } else {
           logger.fatal({ downForMs, sessions: states, authIssues }, "Oturumlar uzun süredir kapalı, kontrollü process restart uygulanıyor");
@@ -410,6 +433,7 @@ async function main() {
   process.on("SIGTERM", () => shutdownHandler("SIGTERM"));
 
   await botManager.initializeBots();
+  attachProcessAuthErrorMonitor(botManager);
   console.log("- Bot başlatma tamamlandı.");
   logger.info("Bot başlatma tamamlandı");
 


### PR DESCRIPTION
### Motivation
- Kalıcı `Signal`/decrypt/auth hata akışlarını (ör. `No session found to decrypt message`, `PreKeyError`) erken tespit edip otomatik restart döngülerini engellemek istendi.
- Eşik aşıldığında yüksek maliyetli grup operasyonlarının sistem kararlılığını bozmasını önlemek amacıyla bu işlemleri geçici olarak askıya almak gerekiyordu.
- 403 `forbidden` hatalarını operasyon bazında sınıflandırıp (admin eksik / bot gruptan düşmüş / WA policy/temporary) anlaşılır log üretmek hedeflendi.
- Tekrarlayan aynı hata mesajlarının log fırtınası yaratmasını engellemek için log-throttle mekanizması istendi.

### Description
- Yeni modül `core/auth-health.js` eklendi; son `AUTH_SIGNAL_WINDOW_MS` (default 5dk) içinde oluşan decrypt/auth hata timestamp’lerini sayan rolling pencere sayaçı, `AUTH_SIGNAL_THRESHOLD` ile eşik kontrolü ve eşik aşılınca `degraded_auth` durumuna geçiş ile TTL (`AUTH_DEGRADED_TTL_MS`) uygular.
- `core/auth-health.js` içinde yüksek maliyetli grup işlemleri (`groupMetadata`, `groupParticipantsUpdate`) için wrapper sağlayan `wrapGroupOpsForSession` implement edildi; oturum `degraded_auth` ise bu operasyonlar tek seferlik `DEGRADED_AUTH_MODE` hatasıyla bloke edilir ve throttle’lı uyarı logu üretilir.
- `core/auth-health.js` 403 hata sınıflandırıcısı (`classifyForbiddenError`) eklenerek hata mesajına göre `missing_admin_privilege`, `bot_removed_or_not_in_group` veya `wa_policy_or_temporary` kategorilerine ayrılır ve bu durumlar da throttle’lı şekilde loglanır.
- `BotManager.initializeBots` (file: `core/manager.js`) içinde her başlatılan bot için `wrapGroupOpsForSession(bot, sessionId)` çağrısı eklendi; böylece koruma bot init sonrası devreye girer.
- Watchdog (`index.js`) tarafında kalıcı auth hatası regex genişletildi (decrypt mesaj örnekleri eklendi), `unhandledRejection` dinleyicisi eklendi ve yakalanan auth/decrypt eksenindeki hatalar `noteError` ile auth-health sayacına beslenir.
- Watchdog `all-bots-down` kararına `hasAnyDegradedSession` sinyali bağlandı; eğer oturumlardan biri `degraded_auth` durumundaysa otomatik restart yerine manual re-auth uyarısı tercih edilecek şekilde davranış değiştirildi ve bu durum `withLogThrottle` ile loglanır.
- Değiştirilen dosyalar: `core/auth-health.js` (yeni), `core/manager.js` (wrap entegrasyonu), `index.js` (watchdog entegrasyonu ve unhandledRejection hook).

### Testing
- Syntax / static checks: `node --check index.js`, `node --check core/manager.js` ve `node --check core/auth-health.js` komutları çalıştırıldı ve hata vermeden geçti.
- Yeni modül fonksiyonları için proje içinde çağırma noktaları (`BotManager.initializeBots`, watchdog) manuel akışla yüklenebilir şekilde bağlandı ve modül yükleme/sentaks hataları bulunmadı (yukarıdaki `node --check` sonuçları başarılı oldu).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b873aebe088321b7b9c61fe23b88d5)