### PR TITLE
Align UserStats uniqueness and upsert conflict target

### DIFF
--- a/core/db-cache.js
+++ b/core/db-cache.js
@@ -76,6 +76,8 @@ function applyDatabaseCaching() {
     return;
   }
 
+  alignUserStatsModel(UserStats);
+
   // ═══════════════════════════════════════════════════════════════════════════
   // 1. AntiDeleteCache → tamamen in-memory, DB'ye hiç gitmez
   // ═══════════════════════════════════════════════════════════════════════════
@@ -391,7 +393,9 @@ function applyDatabaseCaching() {
 
       try {
         if (_origStatsUpsert) {
-          await _origStatsUpsert(instance.dataValues);
+          await _origStatsUpsert(instance.dataValues, {
+            conflictFields: ["userJid", "chatJid"],
+          });
         } else if (_origStatsSave && typeof instance.changed === "function") {
           await _origStatsSave.call(instance);
         } else {
@@ -449,6 +453,53 @@ function applyDatabaseCaching() {
 
   logger.info("db-cache: Veritabanı önbellekleme katmanı aktif");
   console.log("- DB önbellekleme aktif (AntiDelete=bellek, Chat/User/Stats=cache)");
+}
+
+function alignUserStatsModel(UserStats) {
+  try {
+    const attrs = UserStats.rawAttributes || {};
+
+    if (attrs.userJid?.unique) delete attrs.userJid.unique;
+    if (attrs.chatJid?.unique) delete attrs.chatJid.unique;
+
+    const indexes = Array.isArray(UserStats.options?.indexes)
+      ? UserStats.options.indexes
+      : [];
+
+    const filteredIndexes = indexes.filter((idx) => {
+      if (!idx?.unique) return true;
+      const fields = (idx.fields || []).map((f) =>
+        typeof f === "string" ? f : (f?.name || f?.attribute)
+      ).filter(Boolean);
+      return !(
+        fields.length === 1 &&
+        (fields[0] === "userJid" || fields[0] === "chatJid")
+      );
+    });
+
+    const hasCompositeUnique = filteredIndexes.some((idx) => {
+      if (!idx?.unique) return false;
+      const fields = (idx.fields || []).map((f) =>
+        typeof f === "string" ? f : (f?.name || f?.attribute)
+      );
+      return fields.length === 2 && fields[0] === "userJid" && fields[1] === "chatJid";
+    });
+
+    if (!hasCompositeUnique) {
+      filteredIndexes.push({
+        name: "userstats_userjid_chatjid_unique",
+        unique: true,
+        fields: ["userJid", "chatJid"],
+      });
+    }
+
+    UserStats.options.indexes = filteredIndexes;
+    if (typeof UserStats.refreshAttributes === "function") {
+      UserStats.refreshAttributes();
+    }
+  } catch (e) {
+    logger.warn({ err: e }, "db-cache: UserStats model hizalama başarısız");
+  }
 }
 
 function pruneMap(map) {

--- a/migrations/20260316_userstats_composite_unique.sql
+++ b/migrations/20260316_userstats_composite_unique.sql
@@ -1,0 +1,55 @@
+-- PostgreSQL migration: UserStats unique constraint alignment
+-- 1) Drop old single-column unique indexes on ("userJid") and ("chatJid")
+-- 2) Remove duplicates while keeping the newest row per ("userJid", "chatJid")
+-- 3) Create composite unique index on ("userJid", "chatJid")
+
+BEGIN;
+
+-- Drop single-column UNIQUE indexes for userstats.userJid/chatJid, regardless of index name.
+DO $$
+DECLARE
+  idx record;
+BEGIN
+  FOR idx IN
+    SELECT i.relname AS index_name
+    FROM pg_class t
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    JOIN pg_index ix ON ix.indrelid = t.oid
+    JOIN pg_class i ON i.oid = ix.indexrelid
+    WHERE n.nspname = current_schema()
+      AND t.relname = 'userstats'
+      AND ix.indisunique = true
+      AND ix.indnatts = 1
+      AND (
+        SELECT a.attname
+        FROM pg_attribute a
+        WHERE a.attrelid = t.oid
+          AND a.attnum = ANY(ix.indkey)
+        LIMIT 1
+      ) IN ('userJid', 'chatJid')
+  LOOP
+    EXECUTE format('DROP INDEX IF EXISTS %I.%I', current_schema(), idx.index_name);
+  END LOOP;
+END $$;
+
+-- Deduplicate rows before adding composite unique index.
+-- Keep the latest row (highest id, then updatedAt, then ctid fallback) for each (userJid, chatJid).
+WITH ranked AS (
+  SELECT
+    ctid,
+    ROW_NUMBER() OVER (
+      PARTITION BY "userJid", "chatJid"
+      ORDER BY "id" DESC NULLS LAST, "updatedAt" DESC NULLS LAST, ctid DESC
+    ) AS rn
+  FROM "userstats"
+)
+DELETE FROM "userstats" u
+USING ranked r
+WHERE u.ctid = r.ctid
+  AND r.rn > 1;
+
+-- Create target composite unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS userstats_userjid_chatjid_unique
+  ON "userstats" ("userJid", "chatJid");
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- UserStats model had single-column `unique` marks on `userJid`/`chatJid` which conflict with intended per-(userJid,chatJid) uniqueness and can break upserts and cause duplicate rows in PostgreSQL.
- Upsert/flush logic must target a composite uniqueness `(userJid, chatJid)` so runtime writes and DB constraints remain aligned and race/duplicate scenarios are avoided.

### Description
- Add `alignUserStatsModel(UserStats)` in `core/db-cache.js` that removes single-field `unique` flags and ensures the model options include a composite unique index `{ fields: ["userJid","chatJid"], unique: true }`, and refreshes model attributes when possible.
- Call `alignUserStatsModel(UserStats)` at the start of `applyDatabaseCaching` so the in-memory model metadata matches the desired composite uniqueness at runtime.
- Update the periodic flush path in `flushDirtyStats` to call `_origStatsUpsert(instance.dataValues, { conflictFields: ["userJid","chatJid"] })` so Sequelize/PG `ON CONFLICT` targets the new composite index.
- Add a PostgreSQL migration `migrations/20260316_userstats_composite_unique.sql` that drops existing single-column unique indexes on `userstats` (`userJid`/`chatJid`), deduplicates rows keeping the latest per `(userJid, chatJid)`, and creates `userstats_userjid_chatjid_unique` composite unique index.

### Testing
- Ran `node -c core/db-cache.js` to verify the patched file is syntactically valid, and it succeeded. 
- Created and committed the migration `migrations/20260316_userstats_composite_unique.sql` and the code changes; no runtime unit tests are configured in this repo so migration should be applied in staging/production before deploying the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b881174a5083218632bfac5c8766bc)