### PR TITLE
Improve voice transcription API error parsing

### DIFF
--- a/plugins/media.js
+++ b/plugins/media.js
@@ -33,6 +33,31 @@ async function findMusic(file) {
 }
 const Lang = getString("media");
 
+function safeParseErrorBody(data) {
+  if (!data) return null;
+  if (typeof data === "object") return data;
+  if (typeof data === "string") {
+    try {
+      return JSON.parse(data);
+    } catch (_err) {
+      return data;
+    }
+  }
+  return null;
+}
+
+function resolveApiErrorMessage(errorData, fallbackError) {
+  const parsed = safeParseErrorBody(errorData);
+  const apiMessage = parsed && typeof parsed === "object"
+    ? parsed.error?.message || parsed.message || parsed.error
+    : null;
+  if (apiMessage) return apiMessage;
+  if (typeof parsed === "string") {
+    return parsed.slice(0, 160);
+  }
+  return fallbackError?.message || "Bilinmeyen hata";
+}
+
 async function transcribeVoiceMessage(message, targetMessage) {
   let processingMsg;
   try {
@@ -128,15 +153,17 @@ async function transcribeVoiceMessage(message, targetMessage) {
           console.log("✅ OpenAI API başarılı!");
         } catch (openaiError) {
           console.error("❌ Her iki API de başarısız:", openaiError);
+          const errorText = resolveApiErrorMessage(openaiError.data, openaiError.error);
           return await message.edit(
-            `⚠️ _API hatası: ${openaiError.statusCode || 'Bağlantı hatası'}_\n_${openaiError.data ? JSON.parse(openaiError.data).error?.message : openaiError.error?.message || 'Bilinmeyen hata'}_`,
+            `⚠️ _API hatası: ${openaiError.statusCode || 'Bağlantı hatası'}_\n_${errorText}_`,
             message.jid, processingMsg.key
           );
         }
       } else {
         console.error("❌ Groq API hatası ve OpenAI anahtarı yok:", groqError);
+        const errorText = resolveApiErrorMessage(groqError.data, groqError.error);
         return await message.edit(
-          `⚠️ _API hatası: ${groqError.statusCode || 'Bağlantı hatası'}_\n_${groqError.data ? JSON.parse(groqError.data).error?.message : groqError.error?.message || 'Bilinmeyen hata'}_`,
+          `⚠️ _API hatası: ${groqError.statusCode || 'Bağlantı hatası'}_\n_${errorText}_`,
           message.jid, processingMsg.key
         );
       }


### PR DESCRIPTION
### Motivation
- Avoid crashes and confusing messages when transcription API error responses are non-JSON or have different shapes. 
- Prefer a clear, prioritized error string to show to users instead of raw `JSON.parse(...)` access that can throw. 

### Description
- Added `safeParseErrorBody(data)` to safely handle `object` and `string` bodies and return parsed JSON or the raw string without throwing. 
- Added `resolveApiErrorMessage(errorData, fallbackError)` to select a user-facing message preferring API `error/message`, then a shortened raw response string, then a fallback. 
- Replaced the two `JSON.parse(...).error?.message` fallbacks in `transcribeVoiceMessage` with the new helpers to stabilize error reporting in `plugins/media.js`. 

### Testing
- Verified replacements via `rg -n "safeParseErrorBody|resolveApiErrorMessage|JSON.parse\\(openaiError.data\\)|JSON.parse\\(groqError.data\\)" plugins/media.js` which found the new helpers and no remaining direct `JSON.parse(...).error?.message` usage. 
- Ran a syntax check with `node --check plugins/media.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8841d9d988321b88dbea6ecb01d87)