### PR TITLE
media: remove unused temp file from voice transcription

### DIFF
--- a/plugins/media.js
+++ b/plugins/media.js
@@ -1,6 +1,5 @@
 const { Module } = require("../main");
 const fs = require("fs");
-const path = require("path");
 const ffmpeg = require("fluent-ffmpeg");
 const https = require("https");
 const { getTempPath, getTempSubdir } = require("../core/helpers");
@@ -51,8 +50,6 @@ async function transcribeVoiceMessage(message, targetMessage) {
     }
     processingMsg = await message.send("🎙️ _Ses analiz ediliyor..._");
     const audioBuffer = await voiceMsg.download("buffer");
-    const tempFile = path.join(__dirname, `audio_${Date.now()}.ogg`);
-    fs.writeFileSync(tempFile, audioBuffer);
     const boundary = `----WebKitFormBoundary${Date.now()}`;
     const chunks = [];
 


### PR DESCRIPTION
### Motivation
- Remove unnecessary disk write and temporary file creation in `transcribeVoiceMessage` so the transcription flow remains fully buffer-based and avoids leaving orphaned files.

### Description
- Removed `tempFile` creation and `fs.writeFileSync(tempFile, audioBuffer)` from `plugins/media.js` and dropped the now-unused `path` import, keeping the multipart body construction using `audioBuffer` only.

### Testing
- Ran `node -c plugins/media.js` to validate syntax and it succeeded.
- Verified with `rg "tempFile|writeFileSync(tempFile)" -n plugins/media.js` that no references remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8842f71f08321b02996efc87d225b)