### PR TITLE
Improve nexGet handling for binary responses and API errors

### DIFF
--- a/plugins/nexray-komutlar.js
+++ b/plugins/nexray-komutlar.js
@@ -12,13 +12,38 @@ async function nexGet(path, opts = {}) {
     validateStatus: () => true,
     responseType: opts.buffer ? "arraybuffer" : "json",
   });
-  if (opts.buffer && res.status === 200 && res.data?.length > 1000) {
-    return Buffer.from(res.data);
+
+  let payload = res.data;
+  const contentType = (res.headers?.["content-type"] || "").toLowerCase();
+
+  if (opts.buffer) {
+    const buf = Buffer.isBuffer(res.data) ? res.data : Buffer.from(res.data || []);
+
+    if (contentType.includes("application/json") || contentType.includes("text/json")) {
+      try {
+        payload = JSON.parse(buf.toString("utf-8"));
+      } catch {
+        payload = null;
+      }
+    }
+
+    if (res.status === 200 && buf.length > 0 && !contentType.includes("json")) {
+      return buf;
+    }
   }
-  if (res.data?.status && res.data?.result !== undefined) {
-    return res.data.result;
+
+  if (payload?.status && payload?.result !== undefined) {
+    return payload.result;
   }
-  throw new Error(res.data?.error || `HTTP ${res.status}`);
+
+  const errorMsg =
+    payload?.error?.message ||
+    payload?.error ||
+    payload?.message ||
+    payload?.result?.message ||
+    `HTTP ${res.status}`;
+
+  throw new Error(errorMsg);
 }
 
 // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- Make `nexGet` robust when the API returns binary assets or JSON error payloads while running in buffer mode.
- Remove the arbitrary binary size gate and accept smaller valid binaries while still detecting JSON error responses.
- Surface clearer error messages derived from API `error/message` fields instead of opaque HTTP fallbacks.

### Description
- Reworked `nexGet` to store response body in `payload` and to read `content-type` from `res.headers` for content-aware handling.
- In buffer mode the code now creates a `buf` and parses it as JSON when the `content-type` indicates JSON, otherwise it returns the binary when `res.status === 200` and `buf.length > 0` (removed the `> 1000` threshold).
- When a success JSON is returned the function returns `payload.result` as before, and when an error is encountered it constructs `errorMsg` from `payload?.error?.message`, `payload?.error`, `payload?.message`, `payload?.result?.message` with a fallback of `HTTP <status>`.

### Testing
- Ran a Node syntax check with `node -c plugins/nexray-komutlar.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8843ddd908321abdf4df4d96d2551)