### PR TITLE
fix: Decryption ve transaction log gürültüsünü azalt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Lades-MD is a WhatsApp bot built on Node.js (CommonJS) using the Baileys library
 - PM2 is required globally (`npm install -g pm2`).
 - System dependency `webp` (cwebp/dwebp) is needed for sticker functionality.
 - Runtime-generated plugin files (e.g. `temel.js`, `sosyal.js`, `yapayzeka.js`) are created by the bot during initialization — they are not tracked in git and should not be committed.
+- `SUPPRESS_DECRYPTION_LOGS` (default: true) — "No session found to decrypt" / "transaction failed, rolling back" gibi Baileys loglarını trace seviyesine indirir. `SUPPRESS_DECRYPTION_LOGS=false` ile tam log alınır.
 
 ### WhatsApp session troubleshooting
 

--- a/config.js
+++ b/config.js
@@ -23,7 +23,38 @@ const isKoyeb = !!process.env.KOYEB_PUBLIC_DOMAIN;
 const isHeroku = __dirname.startsWith("/lds") && !isKoyeb;
 const isVPS = !isHeroku && !isKoyeb && !isRailway;
 
-const logger = P({ level: process.env.LOG_LEVEL || "warn" });
+const baseLogger = P({ level: process.env.LOG_LEVEL || "warn" });
+
+// Baileys/Signal decryption hataları ve transaction rollback'leri sık görülür;
+// "No session found" / "No matching sessions" genelde LID/session senkronizasyonundan
+// kaynaklanır, kritik değildir. Bu logları debug seviyesine indirerek gürültüyü azalt.
+const SUPPRESS_DECRYPTION_LOGS = process.env.SUPPRESS_DECRYPTION_LOGS !== "false";
+const NOISY_ERROR_PATTERNS = [
+  "failed to decrypt",
+  "transaction failed",
+];
+
+function wrapLogger(log) {
+  if (!log || !SUPPRESS_DECRYPTION_LOGS) return log;
+  const origError = log.error.bind(log);
+  const origChild = log.child?.bind(log);
+  Object.assign(log, {
+    error(...args) {
+      const msg = typeof args[0] === "string" ? args[0] : args[1];
+      if (typeof msg === "string" && NOISY_ERROR_PATTERNS.some((p) => msg.includes(p))) {
+        return log.trace(...args);
+      }
+      return origError(...args);
+    },
+    child(...args) {
+      const child = origChild ? origChild(...args) : log;
+      return wrapLogger(child);
+    },
+  });
+  return log;
+}
+
+const logger = wrapLogger(baseLogger);
 
 function applyPostgresResilience(sequelizeInstance) {
   if (!sequelizeInstance || sequelizeInstance.__pgGuardsApplied) {

--- a/core/sse-guard.js
+++ b/core/sse-guard.js
@@ -2,7 +2,7 @@ const Module = require("module");
 const { logger } = require("../config");
 const { withLogThrottle } = require("./auth-health");
 
-const RECOVERABLE_SSE_REGEX = /(terminated:\s*other side closed|econnreset|socket hang up)/i;
+const RECOVERABLE_SSE_REGEX = /(terminated:\s*other side closed|other side closed|econnreset|socket hang up)/i;
 const BASE_BACKOFF_MS = [1000, 2000, 5000];
 const MAX_BACKOFF_MS = 30000;
 const JITTER_RATIO = 0.2;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Özet

Loglarda sürekli görülen "No session found to decrypt message", "transaction failed, rolling back" ve SSE "terminated: other side closed" hatalarının gürültüsünü azaltır.

## Değişiklikler

### 1. Decryption / transaction log filtreleme (`config.js`)
- Baileys'in `failed to decrypt` ve `transaction failed` logları varsayılan olarak **trace** seviyesine indirilir
- `SUPPRESS_DECRYPTION_LOGS=false` ile tam log alınabilir
- Bu hatalar genelde LID/session senkronizasyonundan kaynaklanır, kritik değildir

### 2. SSE recoverable hata genişletmesi (`core/sse-guard.js`)
- "other side closed" (TypeError öneki olmadan) artık recoverable olarak sınıflandırılır
- Böylece `events.raganork.site` gibi harici SSE bağlantılarında "SSE connection error" yerine throttled "SSE recoverable connection issue" logu kullanılır

### 3. Dokümantasyon (`AGENTS.md`)
- `SUPPRESS_DECRYPTION_LOGS` env değişkeni eklendi

## Test

- `npm start` ile bot başlatıldığında decryption hataları artık trace seviyesinde (LOG_LEVEL=debug olmadan görünmez)
- SSE "other side closed" hataları recoverable olarak işlenir
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-312cb5ee-e152-45ea-9869-b89abaad8db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-312cb5ee-e152-45ea-9869-b89abaad8db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

