### PR TITLE
Fix SQLite schema introspection bypass in DB resilience layer

### DIFF
--- a/core/db-resilience.js
+++ b/core/db-resilience.js
@@ -97,8 +97,18 @@ function applyResilience(sequelizeInstance, opts = {}) {
       normalizedSql.startsWith("DELETE") ||
       normalizedSql.startsWith("CREATE") ||
       normalizedSql.startsWith("ALTER") ||
-      normalizedSql.startsWith("DROP") ||
-      (dialect === "sqlite" && normalizedSql.startsWith("PRAGMA"))
+      normalizedSql.startsWith("DROP")
+    );
+  };
+
+  const isSchemaIntrospectionQuery = (sql) => {
+    if (dialect !== "sqlite" || !sql || typeof sql !== "string") return false;
+    const normalizedSql = sql.trim().toUpperCase();
+    return (
+      normalizedSql.startsWith("PRAGMA ") ||
+      normalizedSql.includes("SQLITE_MASTER") ||
+      normalizedSql.includes("TABLE_INFO(") ||
+      normalizedSql.includes("INDEX_LIST(")
     );
   };
 
@@ -222,6 +232,12 @@ function applyResilience(sequelizeInstance, opts = {}) {
   // --- Query interceptor fabrikası ---
   function createQueryInterceptor(originalFn) {
     return function serializedQuery(sql, ...rest) {
+      if (isSchemaIntrospectionQuery(sql)) {
+        // Sequelize'in describeTable/sync akışları PRAGMA sonuç formatına sıkı bağlıdır.
+        // Bu sorguları kuyruk/tampon katmanına sokmak metadata parse hatalarına yol açar.
+        return originalFn(sql, ...rest);
+      }
+
       if (isAntiDeleteQuery(sql)) {
         return Promise.resolve([[], 0]);
       }


### PR DESCRIPTION
## Summary
- Fixed a critical SQLite query-classification issue in `core/db-resilience.js`.
- Stopped routing SQLite schema-introspection queries (`PRAGMA`, `sqlite_master`, table/index introspection) through the buffered/serialized write path.
- Removed `PRAGMA` from write-query detection so Sequelize metadata calls keep their expected response shape.

## Why this matters
The bot logs showed:
- `Error ensuring fullContent column exists: TypeError: Cannot create property 'unique' on number '0'`

That error happens during Sequelize `describeTable`/schema metadata flow. The previous resilience wrapper treated SQLite `PRAGMA` like write traffic, which can break metadata parsing and trigger startup/runtime schema failures.

## Expected impact
- Eliminates the `fullContent`/`unique on number '0'` schema error path.
- Stabilizes startup and DB model alignment for SQLite.
- Prevents schema checks from being distorted by buffering logic.

## Testing
- Static code inspection only (no runtime execution requested in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdd31b06b88321a2ee9a1f36ec9dad)