### PR TITLE
Normalize self-kick checks using numeric bot IDs (JID/LID)

### DIFF
--- a/plugins/group.js
+++ b/plugins/group.js
@@ -24,6 +24,7 @@ const {
   fetchRecentChats,
 } = require("../core/store");
 const { setVar } = require("./manage");
+const { isBotIdentifier } = require("./utils/lid-helper");
 const handler = config.HANDLER_PREFIX;
 
 
@@ -130,8 +131,7 @@ Module(
     }
     const user = message.mention?.[0] || message.reply_message?.jid;
     if (!user) return await message.sendReply(Lang.NEED_USER);
-    const botId = message.client.user.id.split(":")[0] + "@s.whatsapp.net";
-    if (user === botId) {
+    if (isBotIdentifier(user, message.client)) {
       return await message.sendReply("❌ _Üzgünüm, daha kendimi çıkaracak kadar delirmedim. 😉_");
     }
     await message.client.sendMessage(message.jid, {
@@ -187,12 +187,11 @@ Module(
       );
     }
 
-    const botId = message.client.user.id.split(":")[0] + "@s.whatsapp.net";
     let canKickAnyone = false;
     let adminUsers = [];
 
     for (const user of usersToKick) {
-      if (user === botId) {
+      if (isBotIdentifier(user, message.client)) {
         continue;
       }
       try {
@@ -221,7 +220,7 @@ Module(
 
     for (const user of usersToKick) {
       try {
-        if (user === botId) {
+        if (isBotIdentifier(user, message.client)) {
           await message.sendReply("❌ _Üzgünüm, daha kendimi çıkaracak kadar delirmedim. 😉_");
           continue;
         }
@@ -756,7 +755,7 @@ Module(
         let msg = `_${g1.subject}_ & _${g2.subject}_ grubundaki ortak katılımcılar atılıyor_\n_sayı: ${common.length}_\n`;
         common
           .map((e) => e.id)
-          .filter((e) => !e.includes(message.client.user?.id?.split(":")[0]))
+          .filter((e) => !isBotIdentifier(e, message.client))
           .map(async (s) => {
             msg += "```@" + s.split("@")[0] + "```\n";
             jids.push(s);
@@ -767,8 +766,7 @@ Module(
         });
         for (let user of jids) {
           await new Promise((r) => setTimeout(r, 1000));
-          const botId = message.client.user.id.split(":")[0] + "@s.whatsapp.net";
-          if (user === botId) {
+          if (isBotIdentifier(user, message.client)) {
             await message.sendReply("❌ _Üzgünüm, daha kendimi çıkaracak kadar delirmedim. 😉_");
             continue;
           }

--- a/plugins/utils/lid-helper.js
+++ b/plugins/utils/lid-helper.js
@@ -43,6 +43,22 @@ function getNumericId(identifier) {
     return identifier;
 }
 
+function getBotNumericIds(client) {
+    if (!client || !client.user) return [];
+
+    const botJidNumeric = getNumericId(getBotJid(client));
+    const botLidNumeric = getNumericId(getBotLid(client));
+
+    return [...new Set([botJidNumeric, botLidNumeric].filter(Boolean))];
+}
+
+function isBotIdentifier(identifier, client) {
+    const targetNumeric = getNumericId(identifier);
+    if (!targetNumeric) return false;
+
+    return getBotNumericIds(client).includes(targetNumeric);
+}
+
 function isSudo(identifier, sudoConfig) {
     if (!identifier || !sudoConfig) return false;
 
@@ -151,7 +167,9 @@ module.exports = {
     getBotJid,
     getBotLid,
     getBotNumericId,
+    getBotNumericIds,
     getNumericId,
+    isBotIdentifier,
     isLidParticipant,
     isSudo,
     isFromOwner,

--- a/plugins/warn.js
+++ b/plugins/warn.js
@@ -10,14 +10,11 @@ const {
   getAllWarns,
   censorBadWords,
 } = require("./utils");
+const { getNumericId, isBotIdentifier } = require("./utils/lid-helper");
 
 const handler = HANDLER_PREFIX;
 const warnLimit = parseInt(WARN || "4");
 const sudoUsers = (SUDO || "").split(",");
-
-function getNumericId(jid = "") {
-  return String(jid).split("@")[0];
-}
 
 Module(
   {
@@ -78,8 +75,7 @@ Module(
       const remaining = warnData.kalan ?? warnData.remaining;
 
       if (warnData.exceeded) {
-        const botId = message.client.user.id.split(":")[0] + "@s.whatsapp.net";
-        if (targetUser === botId) {
+        if (isBotIdentifier(targetUser, message.client)) {
           return await message.sendReply("❌ _Üzgünüm, daha kendimi çıkaracak kadar delirmedim. 😉_");
         }
         try {

--- a/tests/lid-helper.test.js
+++ b/tests/lid-helper.test.js
@@ -1,0 +1,26 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isBotIdentifier } = require("../plugins/utils/lid-helper");
+
+const client = {
+  user: {
+    id: "905551112233:12@s.whatsapp.net",
+    lid: "905551112233:34@lid",
+  },
+};
+
+test("self-kick is blocked when target is @s.whatsapp.net", () => {
+  const targetUser = "905551112233@s.whatsapp.net";
+  assert.equal(isBotIdentifier(targetUser, client), true);
+});
+
+test("self-kick is blocked when target is @lid", () => {
+  const targetUser = "905551112233@lid";
+  assert.equal(isBotIdentifier(targetUser, client), true);
+});
+
+test("kick continues for a regular user target", () => {
+  const targetUser = "905559998877@s.whatsapp.net";
+  assert.equal(isBotIdentifier(targetUser, client), false);
+});


### PR DESCRIPTION
### Motivation
- Prevent accidental self-kicks triggered by strict `@s.whatsapp.net` string comparisons by normalizing comparisons to the numeric user id so both JID and LID forms are handled.

### Description
- Added helpers in `plugins/utils/lid-helper.js`: `getBotNumericIds(client)` and `isBotIdentifier(identifier, client)` and exported them for reuse.
- Replaced fragile string checks in `plugins/group.js` (all `groupParticipantsUpdate(..., "remove")` self-check points, `ban`, `at`, and `common kick` flows) to use `isBotIdentifier(...)` so both `@s.whatsapp.net` and `@lid` forms match the bot.
- Updated `plugins/warn.js` to reuse `getNumericId` and `isBotIdentifier` from the lid-helper so warn-limit kicks also do numeric-based self-detection.
- Added unit tests in `tests/lid-helper.test.js` that validate the normalization and guard logic.

### Testing
- Ran the new unit tests with `node --test tests/lid-helper.test.js` and all tests passed (3/3).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdd7ecb75483219c978a05e163d3bd)