### PR TITLE
Şarkı seçim akışında arama listesini durum mesajına dönüştür

### DIFF
--- a/plugins/youtube.js
+++ b/plugins/youtube.js
@@ -696,13 +696,19 @@ Module(
         }
 
         const selectedVideo = results[selectedNumber - 1];
-        let downloadMsg;
-
         try {
           const safeTitle = censorBadWords(selectedVideo.title);
-          downloadMsg = await message.sendReply(
-            `_🔻 İndirilip yükleniyor..._ *${safeTitle}*`
-          );
+          const quotedListKey =
+            message.reply_message?.data?.key || message.reply_message?.key;
+          const canEditQuotedList = !!quotedListKey;
+
+          if (canEditQuotedList) {
+            await message.edit(
+              `_🔻 İndirilip yükleniyor..._ *${safeTitle}*`,
+              message.jid,
+              quotedListKey
+            );
+          }
 
           const result = await nexray.downloadYtMp3(selectedVideo.url);
           if (!result || !result.url) throw new Error("Nexray failed");
@@ -713,19 +719,27 @@ Module(
             fileName: `${safeTitle}.mp3`,
           }, { quoted: message.data });
 
-          await message.edit(
-            `_✅ Hazır!_ *${safeTitle}*`,
-            message.jid,
-            downloadMsg.key
-          );
+          if (canEditQuotedList) {
+            await message.edit(
+              `_✅ Hazır!_ *${safeTitle}*`,
+              message.jid,
+              quotedListKey
+            );
+          } else {
+            await message.sendReply(`_✅ Hazır!_ *${safeTitle}*`);
+          }
         } catch (error) {
           console.error("Şarkı indirme hatası:", error);
-          if (downloadMsg) {
+          const quotedListKey =
+            message.reply_message?.data?.key || message.reply_message?.key;
+          if (quotedListKey) {
             await message.edit(
               "_⚠️ İndirme başarısız! Lütfen tekrar deneyin._",
               message.jid,
-              downloadMsg.key
+              quotedListKey
             );
+          } else {
+            await message.sendReply("_⚠️ İndirme başarısız! Lütfen tekrar deneyin._");
           }
         }
       } catch (error) {
@@ -1146,4 +1160,3 @@ Module(
     }
   }
 );
-


### PR DESCRIPTION
## Özet
- `.şarkı ara <sorgu>` sonucunda gelen listeye sayı ile yanıtlandığında, botun yeni bir durum mesajı atması yerine mevcut YouTube sonuç mesajını düzenlemesi sağlandı.
- İndirme başlangıcında sonuç mesajı `_🔻 İndirilip yükleniyor..._` metnine çevriliyor.
- Ses gönderimi tamamlanınca aynı mesaj `_✅ Hazır!_` durumuna güncelleniyor.
- Liste mesajı anahtarı alınamazsa (nadiren), geriye dönük uyumluluk için ayrı durum mesajı gönderme davranışı korunuyor.

## Neden
- Gereksiz ekstra mesajları azaltıp sohbet kirliliğini önlemek.
- Kullanıcının seçim yaptığı mesaj üzerinde süreç durumunu net göstermek.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde00e53408321a5dd5852c279bbee)